### PR TITLE
Add 02 Normalize SCE script

### DIFF
--- a/02-normalize-sce.R
+++ b/02-normalize-sce.R
@@ -1,7 +1,8 @@
-## Read in SingleCellExperiment RDS object that has been filtered for highly
-## expressed cells, using miQC or a manual filtering method, and filtered for
-## highly expressed genes. This script will then normalize the filtered object
-## using functions from the `scran` and `scater` packages.
+## Read in SingleCellExperiment RDS object that has been filtered to remove
+## cells on the basis of their mitochondrial read percentage and detected genes
+## and to remove lowly expressed or undetected genes. This script will then
+## normalize the filtered object using functions from the `scran` and `scater` 
+## packages.
 
 # Command line usage:
 


### PR DESCRIPTION
Closes #4

In this PR, the following steps are taken for normalization:

- command line options are set up
- the filtered SCE rds file (output of `01-filter-sce.R`) is read in
- `scran::quickCluster()` is used to cluster similar cells in the filtered SCE, `scran::computeSumFactors()` is used to compute the sum factors for each cell cluster grouping, and `scater::logNormCounts()` is used to normalize and transform the data in the object
- the most variable genes (top 2000) are then found using scran's functions
- the PCA and UMAP results are added to the now normalized SCE object and saved

## Questions for reviewers

- Do we still believe adding the PCA and UMAP results at the end of this script is the better suited idea or should they be added in a separate script?
- Does the formatting of the command line options, output files, and the script in general seem reasonable?