### PR TITLE
Generalize handling of marker gene lists

### DIFF
--- a/utils/map-marker-genes.R
+++ b/utils/map-marker-genes.R
@@ -1,8 +1,8 @@
 # Map provided gene identifiers for downstream use in the marker genes analysis.
-# The format of the provided gene identifiers, and the column in which they can
-# be found in the input file, should be specified using the appropriate
-# command line flags outlined below. The desired gene identifiers to be mapped
-# to should also be specified via the appropriate command line flag.
+# The type of gene identifiers you are converting *from*, the column in which
+# they can be found in the input file, and the type of gene identifiers you are
+# converting *to* should all be specified using the command line flags outlined
+# below. 
 # 
 # Run `Rscript utils/map-marker-genes.R --help` for more on what values should
 # be specified for each of the command line flags.


### PR DESCRIPTION
Closes #5 

This PR attempts to generalize the handling of provided lists of marker genes by adding a script at `utils/map-marker-genes.R`, using [`00-map-marker-genes.R`](https://github.com/AlexsLemonade/dana-single-cell/blob/main/marker-genes/00-map-marker-genes.R) in the dana project repo as a guide as mentioned on #5.

In this PR, 
- a file with at least a column containing marker gene identifiers, is read in
- then based on the specified type of gene identifiers (gene symbol or ensembl id), mapping is performed and an output file is saved with the mapped values (retaining any additional columns that may have been included in the input file)

## Questions for reviewers

- The script in this PR successfully ran when provided with the gene symbols associated with the public NB dataset analysis https://github.com/AlexsLemonade/sci-projects/issues/55, however there was an instance where a gene symbol mapped to more than one Ensembl id:
<img width="287" alt="Screen Shot 2021-10-05 at 2 45 01 PM" src="https://user-images.githubusercontent.com/43576623/136094699-102bbfce-04a0-4ba8-9b59-9d5981a82d92.png">

Are we fine with keeping both mapped values and saving them in the output file as seen above (for both this case and any future cases)?

- Does the structure of this script seem to accomplish what we set out to do in #5 or do you have any suggestions for refactoring to provide further flexibility?
- Does the placement of this script seem best suited for this analysis? I am thinking along the lines of optionally running this script an the upcoming overall shell script.

