### PR TITLE
Add dimension reduction script

### DIFF
--- a/03-dimension-reduction.R
+++ b/03-dimension-reduction.R
@@ -46,8 +46,8 @@ option_list <- list(
   optparse::make_option(
     c("-o", "--overwrite"),
     action = "store_true",
-    help = "specify whether or not to overwrite any existing dimension reduction
-            results; the default is yes, overwrite the results",
+    help = "specifies whether or not to overwrite any existing dimension reduction
+            results"
   )
 )
 
@@ -91,22 +91,22 @@ dim_reduction <- function(normalized_sce, subset_genes) {
   normalized_sce <- runUMAP(normalized_sce, dimred = "PCA")
 }
 
-
 # if there are dimension reductions results in the sce and the user has not
 # specified whether or not to overwrite the results, stop script with an error
 if (!is.null(reducedDims(normalized_sce))) {
-  if(opt$overwrite){
+  if (!is.null(opt$overwrite)) {
     # perform dimensionality reduction
     message("Overwriting dimension reduction PCA and UMAP results.")
     normalized_sce <- dim_reduction(normalized_sce, subset_genes)
   } else {
     stop(
-      "Do you want to overwrite the existing dimension reduction
-               results? Specify 'yes' or 'no' using the --overwrite flag."
+      "Dimensionality reduction results exist. Skipping dimensionality reduction
+      steps. If you want to overwrite the existing results, use the --overwrite
+      flag."
     )
   }
 } else {
-  # perform dimensionality reduction 
+  # perform dimensionality reduction
   normalized_sce <- dim_reduction(normalized_sce, subset_genes)
 }
 


### PR DESCRIPTION
Closes #14 

This PR adds PCA and UMAP dimensionality results to the provided normalized SingleCellExperiment object, or in other words calculates and saves the results in the same file/at the same filepath as the normalized input file provided.

As suggested on issue #14, the [end of the `01-filter-normalize.R`](https://github.com/AlexsLemonade/dana-single-cell/blob/e62b1a936ba65916e1b884f9c4845290cbc527bc/analysis/01-filter-normalize.R#L233-L248) script over in the `dana-single-cell` repo was used as a guide for implementing what's in this PR, using `scran` functions to model gene variance and `scater`'s `runPCA()` and `runUMAP()` functions to calculate the dimensionality results.

A `top_n` option was also added in this PR as to further generalize this script.

## Questions for reviewers

- Should the output of this script be saved in a separate file or do we think it's fine to save things at the same filepath as the input file?
- Does the overall structure of the script seem to do what we want -- add dimension reduction results to our SCE object, while making the script as generalizable as possible?
