### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 **Any comments, concerns, or questions important for reviewers**
 
 **Checklist**
+
 Place an `x` in all boxes that you have completed.
 
 - [ ] I have run the most recent version of the code


### PR DESCRIPTION
Closes #63. 
This PR adds a general PR template to be used in this repo. The template asks you to provide the issue that is being addressed, why you are making these changes, what these changes are and what steps you took to make them, and then if you tried any alternative routes before choosing this option. To me this made sense to keep as the main PR template for the repo as it could be broadly applicable to most changes being made here and would help provide people a backbone when filing PRs. 

I do anticipate that as we develop the pipeline further, we may want to add specific PR templates for specific feature additions in which we could add links to the main template. However, right now it made the most sense to make one main template to build on later. I am open to others opinions if they have them. 