### PR TITLE
Update README with Snakemake instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Note that we have also provided a [configuration file](https://snakemake.readthe
 
 The default `config.yaml` variables that are relevant to your project include the following:
 
-- `data_dir`: path to the main data directory that holds your samples' files (expected within this directory would be individual folders for each sample, with the folder name corresponding to the sample ID, that hold the pre-processed RDS files with the file name in the format, `<library_id>_filtered.rds`)
+- `data_dir`: path to the main data directory that holds your samples' files
+	- expected within this directory would be individual folders for each sample, with the folder name corresponding to the sample ID, that hold the pre-processed RDS files with the file name in the format, `<library_id>_filtered.rds`
 - `results_dir`: path to a results directory to hold your project's output files
 - `project_metadata`: path to your specific project metadata TSV file with the columns as follows:
     -  `sample_id`, whose values are the names of the sample folders


### PR DESCRIPTION
**Issue Addressed**
Closes #68

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This repo's current README includes outdated instructions on how to run the bash script for the core pipeline and should rather include updated instructions on how to run the snakefile.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR updates the README with instructions on installing snakemake and relevant package dependencies, as well as running the Snakefile with relevant modifications provided to the `--config` flag (as to modify the default variable in the `config.yaml` file). 

For reference, I have tested all of the instructions added in this PR (included Snakemake local installation and the implementation of the Snakefile with modified variables supplied to `--config`).

**Any comments, concerns, or questions important for reviewers**

- Are the added instructions easy to follow for you? Are they suffice at this point in time?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code (NA)
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports (NA)
- [x] I have added all necessary documentation (if applicable)