### PR TITLE
Script for adding clustering assignments to SCE object as part of core pipeline

### DIFF
--- a/04-clustering.R
+++ b/04-clustering.R
@@ -8,7 +8,7 @@
 #   --sce "results/Gawad_processed_data/SCPCS000245/SCPCL000343_miQC_downstream_processed_normalized_reduced_sce.rds" \
 #   --seed 2021 \
 #   --cluster_type "louvain" \
-#   --nnparam 15
+#   --nearest_neighbors 10
 
 ## Set up -------------------------------------------------------------
 
@@ -46,7 +46,7 @@ option_list <- list(
   optparse::make_option(
     c("-i", "--sce"),
     type = "character",
-    default = "results/Gawad_processed_data/SCPCS000245/SCPCL000343_miQC_downstream_processed_normalized_reduced_sce.rds",
+    default = NULL,
     help = "path to normalized SCE",
   ),
   optparse::make_option(


### PR DESCRIPTION
**Issue Addressed**
Closes #74. 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
To continue the core pipeline, we would like to add clustering assignments for each cell to the SCE object so that we can provide users with an SCE object that has dimensionality reduction embeddings along with a default clustering assignment. This would then be used as input for creating a UMAP plot as part of an html report provided with the core pipeline so that users would get the UMAP plot with the colors they want. Not included in this script is the option to test out multiple clustering options or gather statistics on their clustering results. That will be a separate module where we allow users to test different clustering methods, parameters, and obtain statistics summarizing the results. 

Here the purpose is to provide a default clustering method that is the most widely reliable across the most amount of samples. We are setting the default clustering method to be graph based with the `louvain` detection algorithm and using the `jaccard` weighting scheme (the defaults used in Seurat). We also are using the default nearest neighbors parameter of 10.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
I added the script, `04-clustering.R` that will be appended to the core workflow and run after dimensionality reduction. The script takes as input an SCE object that has been normalized and has PCA results stored in the object. It also requires a clustering type which can be either `louvain` or `walktrap`, although the default method (and the method I plan to implement in the snakemake workflow is `louvain`). It also allows for changes to the nearest neighbors parameter, whose default is set at 10, the default value for the `NNGraphParam()` function. 
Within the script the weighting scheme to use for graph based clustering is determined based on the clustering type that is chosen. Here, the options are to run it with `louvain` and a weighting scheme of `jaccard` or to run it with `walktrap` and a weighting scheme of `rank` (the default method found in the `scran` pipeline). This limits users to only use methods that are typically implemented together and that we have tested ourselves, rather than being able to mix and match different detection algorithms with different weighting schemes. 
After identifying the weighting scheme, clustering is performed using the [`graph_clustering` function](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/59b57416cc5c475e7b73f37eacd086376e41eb65/utils/clustering-functions.R#L59-L125) we have in `utils/clustering-functions.R`.  This function performs the clustering and then adds the clustering results to the `colData` of the sce object. 
Finally, the SCE is written out to the provided output file. 

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->
I did debate the concept of checking if the clustering results already existed in the SCE before performing clustering or not and wondered if that was something we wanted to do. One option I had thought of was to check for the cluster assignments to be there and if they were already there to skip clustering and print out a warning, potentially offering the option to overwrite the clustering results. Is that something we would like or not something we need? 

I also went back and forth on making the weighting schemes an argument or not, but in the end thought that we would want to minimize choice with this script since we are trying to simplify clustering here and then guide users to explore clustering separately. But I'm open to suggestions on this if others feel differently.  

**Any comments, concerns, or questions important for reviewers**

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)