### PR TITLE
Initiate core analysis template notebook

### DIFF
--- a/core-analysis-report-template.Rmd
+++ b/core-analysis-report-template.Rmd
@@ -32,7 +32,6 @@ knitr::opts_chunk$set(
 library(readr)
 ```
 
-## Read in data
 
 ```{r}
 pre_processed_sce <- read_rds(file.path(params$pre_processed_sce))


### PR DESCRIPTION
**Issue Addressed**
Closes #114

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
As noted on the original issue, we want a template notebook that is rendered upon completion of the core analysis pipeline to show the steps that were taken throughout the pipeline and any beneficial results/plots.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR adds a `core-analysis-report-template.Rmd` file, that just reads in the pre-processed and processed sce files and gives the number of cells in each of these files.

In order to run this notebook, I was able to use the following command:
```
Rscript -e "rmarkdown::render('core-analysis-report-template.Rmd', clean = TRUE,
              output_file = 'results/Gawad_processed_data/SCPCS000216/SCPCL000290_core_analysis_report.html',
              params = list(sample = 'SCPCS000216',
                            library = 'SCPCL000290',
                            pre_processed_sce = 'data/Gawad_processed_data/SCPCS000216/SCPCL000290_filtered.rds',
                            processed_sce = 'results/Gawad_processed_data/SCPCS000216/SCPCL000290_miQC_processed_sce.rds'),
              envir = new.env())"
```

Noting that this means the output html file is being stored in the `results` directory and therefore is not included in this PR.
For reference, here is the rendered html file associated with testing what's in this PR:
[SCPCL000290_core_analysis_report.html.zip](https://github.com/AlexsLemonade/scpca-downstream-analyses/files/8781724/SCPCL000290_core_analysis_report.html.zip)


**Any comments, concerns, or questions important for reviewers**
- Does this PR seem to adequately address #114?
- Note that in the template notebook, the terms `pre_processed_sce` and `processed_sce` are being used as I was hesistant to use `unfiltered` for the original sce file since it _has_ been through some level of filtering in this case -- what do you think about this decision?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)