### PR TITLE
Fix `gene_means_cutoff` flag

### DIFF
--- a/01-filter-sce.R
+++ b/01-filter-sce.R
@@ -113,10 +113,10 @@ option_list <- list(
   ),
   optparse::make_option(
     c("--prob_compromised_cutoff"),
-    type = "integer",
+    type = "double",
     default = 0.75,
     help = "probability compromised cutoff used for filtering cells if using miQC",
-    metavar = "integer"
+    metavar = "double"
   ),
   optparse::make_option(
     c("-f", "--filtering_method"),


### PR DESCRIPTION
**Issue Addressed**
Closes #121

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Per the relevant issue, it was noticed that we were setting up the optparse option related to `gene_means_cutoff` in `01-filter-sce.R` as an integer rather than a double, but providing (and implementing) a default value of 0.1. 

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR changes `integer` to `double` for the `gene_means_cutoff` optparse option and also removes an option that was no longer being implemented in the `01-filter-sce.R` script.

**Any comments, concerns, or questions important for reviewers**

It appears that setting `gene_means_cutoff` as an integer was indeed _not_ performing like we wanted and honoring our 0.1 cutoff, but instead rounding our cutoff to an integer (0). 

See the dimensions and minimum values below of the test filtered rds file from before (`old_sce`) and after the changes made in this PR (`new_sce`).

<img width="113" alt="Screen Shot 2022-06-02 at 10 09 56 AM" src="https://user-images.githubusercontent.com/43576623/171676944-0ee7ed2b-bce1-4166-8f12-9ebf2078952b.png">
<img width="221" alt="Screen Shot 2022-06-02 at 10 11 38 AM" src="https://user-images.githubusercontent.com/43576623/171677048-2d6eb525-7095-4d56-b304-7d393ea2f92f.png">

- The remaining optparse options in `01-filter-sce.R` seemed fine to be left as integers as I believe we would be expecting integers in those cases, but I could be wrong -- any thoughts here?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)