### PR TITLE
Save miQC model to filtered SCE

### DIFF
--- a/01-filter-sce.R
+++ b/01-filter-sce.R
@@ -234,9 +234,8 @@ if (opt$filtering_method == "manual") {
                           posterior_cutoff = opt$prob_compromised_cutoff,
                           verbose = FALSE)
       
-      # save model and pre-filtered sce object in metadata for plotting later
+      # save model in metadata for plotting later
       metadata(filtered_sce)$miQC_model <- model
-      metadata(filtered_sce)$original_sce <- sce_qc
       
       # Plot model
       filtered_model_plot <- miQC::plotModel(sce_qc, model)


### PR DESCRIPTION
**Issue Addressed**
Closes #116 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
For plotting purposes later, we will want to save the miQC model to the metadata of the filtered SCE object that will be passed to the template Rmd.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
In this PR, the `01-filter-sce.R` is modified to include the addition of the miQC model to the metadata of the filtered sce object when miQC filtering is implemented.

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->
The `sce_qc` pre-filtered object is also saved to the metadata of the filtered sce as I realized we need this original sce for running the `miQC::plotFiltering()` function (after encountering a dimensions error when attempting to supply the filtered sce to this function):
<img width="607" alt="Screen Shot 2022-06-07 at 8 55 37 AM" src="https://user-images.githubusercontent.com/43576623/172455485-9b1a7315-650e-4a28-a193-06cd9e5d7adc.png">

I have also confirmed that running this will produce the same filtering plot we currently have for this particular sample.

**Any comments, concerns, or questions important for reviewers**
Do the changes made seem to tackle #116 in the best suited way?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)