### PR TITLE
Modify Snakefile to run the workflow from a different directory 

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,6 +1,6 @@
 import pandas as pd
 
-configfile: "config.yaml"
+configfile: os.path.join(workflow.basedir, "config.yaml")
 
 # getting the samples information
 samples_information = pd.read_csv(config["project_metadata"], sep='\t', index_col=False)
@@ -28,7 +28,7 @@ rule filter_data:
     output:
         downstream_filtered_rds = temp(os.path.join(config["results_dir"], "{sample_id}/{library_id}_{filtering_method}_downstream_processed_sce.rds"))
     shell:
-        "Rscript --vanilla 01-filter-sce.R"
+        "Rscript --vanilla {workflow.basedir}/01-filter-sce.R"
         "  --sample_sce_filepath {input}"
         "  --sample_id {wildcards.sample_id}"
         "  --library_id {wildcards.library_id}"
@@ -49,7 +49,7 @@ rule normalize_data:
     output:
         temp("{basename}_downstream_processed_normalized_sce.rds")
     shell:
-        "Rscript --vanilla 02-normalize-sce.R"
+        "Rscript --vanilla {workflow.basedir}/02-normalize-sce.R"
         "  --sce {input}"
         "  --seed {config[seed]}"
         "  --output_filepath {output}"
@@ -60,7 +60,7 @@ rule dimensionality_reduction:
     output:
         temp("{basename}_downstream_processed_normalized_reduced_sce.rds")
     shell:
-        "Rscript --vanilla 03-dimension-reduction.R"
+        "Rscript --vanilla {workflow.basedir}/03-dimension-reduction.R"
         "  --sce {input}"
         "  --seed {config[seed]}"
         "  --top_n {config[n_genes_pca]}"
@@ -73,7 +73,7 @@ rule clustering:
     output:
         "{basename}_processed_sce.rds"
     shell:
-        "Rscript --vanilla 04-clustering.R"
+        "Rscript --vanilla {workflow.basedir}/04-clustering.R"
         "  --sce {input}"
         "  --seed {config[seed]}"
         "  --cluster_type {config[cluster_type]}"


### PR DESCRIPTION
**Issue Addressed**

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Currently, the Snakefile is only set up to be able to run as if you are running from inside this repository and all paths are relative to the root of this directory. However, we would like to be able to run the Snakefile and workflow from different locations and for external users, it would be helpful for them to be able to refer to the Snakefile while working in their directories. There are a series of changes that need to take place in order to do that, but while I was working on AlexsLemonade/sc-data-integration#11, I was trying to run the workflow by providing the path to the Snakefile with the `-s` option. This was failing because it couldn't find a config file since we specify `config=config.yaml` so it was attempting to look in the directory that I was running from for `config.yaml` instead of in the directory where the Snakefile is located in. This is the same for the actual scripts we were trying to run as well, where it was looking in the relative path to where I was running the Snakefile, so it was unsuccessful. 

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
To make sure that all of the files that are needed for the actual Snakefile to work including the config and Rscripts, I made use of the `workflow.basedir` variable in Snakemake. This finds the base directory for the Snakefile and then we can tell the workflow to look in that directory for the files rather than the directory where you are running snakemake from. This worked and makes it so you can run the Snakefile from any directory by using `snakemake -s <path to snakefile>`. 

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->
I also tried to provide the config file at the command line by using the `--configfile` option. That leads to successful building of the job list, but it then is unable to find the Rscripts and fails at the first rule. 

**Any comments, concerns, or questions important for reviewers**
One thing to note that although this allows the config and scripts to be found so the `01-filter-sce.R` script starts, if running from a different directory, the script will fail because there are issues with loading the R project and the mito file which I will file issues for. I wanted to make this change first and then deal with the next set of issues to allow for it to be fully portable from outside of this repo. These changes should not affect the ability to run the Snakefile from within this repo as we were doing previously. 

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)