### PR TITLE
Add `markdown` package to renv.lock file

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1019,6 +1019,13 @@
       "Repository": "RSPM",
       "Hash": "41e7097a7a02db986344eeca0d8a49ac"
     },
+    "markdown": {
+      "Package": "markdown",
+      "Version": "1.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Hash": "61e4a10781dd00d7d81dd06ca9b94e95"
+    },
     "matrixStats": {
       "Package": "matrixStats",
       "Version": "0.61.0",


### PR DESCRIPTION
**Issue Addressed**
https://github.com/AlexsLemonade/scpca-downstream-analyses/pull/138#issuecomment-1165902479

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Per https://github.com/AlexsLemonade/scpca-downstream-analyses/pull/138#issuecomment-1165902479, a prompt to install the `markdown` package was encountered when testing PR #138 for review purposes. This PR adds the `markdown` package to renv to ensure this prompt does not appear in future instances. 

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
The `markdown` package was added to the `renv.lock` file using the `renv::snapshot()` function.

**Any comments, concerns, or questions important for reviewers**
- Does this appear to handle the prompt mentioned in review comment https://github.com/AlexsLemonade/scpca-downstream-analyses/pull/138#issuecomment-1165902479 @sjspielman?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)