### PR TITLE
Add M1 setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Clicking [this link](https://cran.r-project.org/bin/macosx/base/R-4.1.3.pkg) wil
 You will also need to install `gfortan`, a Fortran compiler, to facilitate building certain R packages.
 Clicking [this link](https://mac.r-project.org/tools/gfortran-8.2-Mojave.dmg) will download the `gfortran` compiler, and again follow the installation instructions to install it.
 
-If you experience library-related errors that indicate R can't find the Fortran compiler (while [building your conda environment](#snakemakeconda-installation) or [independently setting up](#independent-installation)), you will want to create the file and/or add the following lines to the file `~/.R/Makevars`:
+If you experience library-related errors that indicate R can't find the Fortran compiler while setting up `renv`, you will want to create the file and/or add the following lines to the file `~/.R/Makevars`:
 
 ```
 FC  = /usr/local/gfortran/bin/gfortran


### PR DESCRIPTION
**Issue Addressed**
Closes #141 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Setting up R and RStudio on M1 computers requires several extra steps that other operating systems do not require, and these extra steps are not well documented anywhere. Moving forward, more folks will be on M1 machines and will need these setup instructions.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
I added a file `instructions-mac-m1.md` which contains a minimal set of instructions for getting started. I did not include any screenshots because I suspected the main audience will already have some comfort with computing and won't need, for example, an in-depth explanation of how to open Terminal etc. I'll also note I think the last item in the instructions is confusing. It was hard to explain, so please let me know if you can think of a way to say this more clearly.
I also linked the instructions file from the overall `README.md`, but I'm not sure I put the link in the best place.


**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->
N/A

**Any comments, concerns, or questions important for reviewers**
This might be good for @cbethell to formally test out since she has *only* been working on the server for this project if I am not mistaken.
