### PR TITLE
Move default issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,10 +1,9 @@
+---
+name: General Issues
+about: General issues related to scpca-downstream-analyses
+---
+
 _Please label your issue as either `enhancement`, `visualization`, `bug`, or `documentation`._
-
-_If filing an issue for a new release use the release checklist template_
-(Use the 'Preview' view to click on the link below)
-<a href="?expand=1&template=release-checklist.md"> Release Checklist Issue template </a>
-
-For all other issues, delete the above text and this line and use the template below.
 
 **Please provide some background on the proposed additions or changes.**
 <!--Include a clear and concise description of why the changes are needed.


### PR DESCRIPTION
The changes merged in #186 caused the release checklist to appear as the main issue to file and then the default issue template to only show up if you click `file a blank issue`. I was not a fan of that, so I moved the default template to within the `ISSUE_TEMPLATE` folder and re-named it as a `General Issue` to file so there should be two options when you go to file: `General Issue` and `Release Checklist`. I wasn't quite sure what to name it so if others have different name ideas let me know. 