### PR TITLE
go back to path joining

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -53,7 +53,7 @@ rule filter_data:
     input:
         get_input_rds_files
     output:
-        temp("{config.results_dir}/{sample_id}/{library_id}_{filtering_method}_filtered.rds")
+        temp(os.path.join(config['results_dir'], "/{sample_id}/{library_id}_{filtering_method}_filtered.rds"))
     conda: "envs/scpca-renv.yaml"
     shell:
         "R_PROFILE_USER='{workflow.basedir}/.Rprofile'"


### PR DESCRIPTION
**Issue Addressed**
https://github.com/AlexsLemonade/sc-data-integration/pull/94#pullrequestreview-1075786228

**What is the purpose of these changes?**
We had a mysterious error when running this workflow and it turns out it was the result of some poor choices I made in my last PR where I thought I could get clever and pull the config setting straight into the path description.

**What changes did you make?**
Stopped trying to be so clever and went back to `os.path.join`

**Were there any other solutions that you tried?**
Many! I did a bunch of disruptive stuff first that didn't work.

I found the error finally by completely deleting the results directory for the example I was running, which made it realize that a dependency wasn't available (since I had deleted it) and allowed me to finally track down the error.

**Any comments, concerns, or questions important for reviewers**

It turns out that `--forceall` is not always a sufficient test!

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)