### PR TITLE
fix extra slash

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -53,7 +53,7 @@ rule filter_data:
     input:
         get_input_rds_files
     output:
-        temp(os.path.join(config['results_dir'], "/{sample_id}/{library_id}_{filtering_method}_filtered.rds"))
+        temp(os.path.join(config['results_dir'], "{sample_id}/{library_id}_{filtering_method}_filtered.rds"))
     conda: "envs/scpca-renv.yaml"
     shell:
         "R_PROFILE_USER='{workflow.basedir}/.Rprofile'"


### PR DESCRIPTION
This quick hotfix PR is to remove an extra slash that was disrupting a full run of the workflow. this was discovered when the example results directory was not present, but would likely affect other non-example runs as well. https://github.com/AlexsLemonade/scpca-downstream-analyses/pull/202#issuecomment-1224233458