### PR TITLE
Add docs to clustering template notebook

### DIFF
--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -21,10 +21,7 @@ output:
     code_folding: hide
 ---
 
-This notebook will plot the output of the 
-`optional-clustering-analysis/clustering-calculations.R` script, which allows 
-for additional types of clustering across a range of parameters to be calculated
-on gene expression data associated with a single sample of the dataset of interest.
+This notebook will plot the output of the `optional-clustering-analysis/clustering-calculations.R` script, which allows for additional types of clustering across a range of parameters to be calculated on gene expression data associated with a single sample of the dataset of interest.
 
 ## Set Up
 
@@ -130,9 +127,7 @@ summary_stability_stats_df <- summary_stability_stats_df %>%
 
 ## UMAP plot results for `r params$library`
 
-Below is a set of UMAP plots, where each panel corresponds to clustering 
-performed with a given clustering parameter and each cell is colored based on
-the cell's cluster assignment. 
+Below is a set of UMAP plots, where each panel corresponds to clustering performed with a given clustering parameter and each cell is colored based on the cell's cluster assignment.
 Here clustering was performed using `r params$cluster_type` clustering.
 
 ```{r}
@@ -161,20 +156,14 @@ cowplot::plot_grid(plotlist = plot_list, ncol = num_col)
 ## Evaluating clustering
 
 Below we evaluate the clustering results across each of the parameters tested. 
-We will look at the cluster purity, silhouette width, and cluster stability for 
-each clustering type and nearest neighbors value used.
-For a more in depth discussion on these metrics and how they can be used to 
-identify the optimal clustering results, see the [advanced clustering chapter in Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.15/OSCA.advanced/clustering-redux.html#motivation).
+We will look at the cluster purity, silhouette width, and cluster stability for each clustering type and nearest neighbors value used.
+For a more in depth discussion on these metrics and how they can be used to identify the optimal clustering results, see the [advanced clustering chapter in Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.15/OSCA.advanced/clustering-redux.html#motivation).
 
 #### Purity plots
 
-The purity plots below represent each cell as the proportion of neighboring 
-cells that are assigned to the same cluster.
-Well-separated clusters should show little overlap between member and 
-neighboring cells, and therefore high purity values for all member cells.
-The cluster purity range is `0` to `1`. Therefore purity values that are
-consistently greater than `0.9` indicate that most cells in each cluster are 
-primarily surrounded by other cells belonging to the same cluster.
+The purity plots below represent each cell as the proportion of neighboring cells that are assigned to the same cluster.
+Well-separated clusters should show little overlap between member and neighboring cells, and therefore high purity values for all member cells.
+The cluster purity range is `0` to `1`. Therefore purity values that are consistently greater than `0.9` indicate that most cells in each cluster are primarily surrounded by other cells belonging to the same cluster.
 
 ```{r}
 # Plot individual cluster purity stats
@@ -185,14 +174,10 @@ purity_plots + theme(text = element_text(size = 12), legend.text = element_text(
 
 #### Silhouette width plots
 
-The silhouette width plots below represent how well-separated each of the 
-clusters are.
-For each cell, the average distance to all cells in the same cluster and the 
-average distance to all cells in another cluster, are calculated. 
-The silhouette width for each cell is defined as the difference between these 
-two values divided by their maximum.
-Therefore, cells will ideally have large positive silhouette widths, as this 
-would mean that the cells of one cluster are well-separated from other clusters.
+The silhouette width plots below represent how well-separated each of the clusters are.
+For each cell, the average distance to all cells in the same cluster and the average distance to all cells in another cluster, are calculated.
+The silhouette width for each cell is defined as the difference between these two values divided by their maximum.
+Therefore, cells will ideally have large positive silhouette widths, as this would mean that the cells of one cluster are well-separated from other clusters.
 The silhouette width range is `-1` to `1`.
 
 ```{r}
@@ -204,11 +189,8 @@ silhouette_plots + theme(text = element_text(size = 12), legend.text = element_t
 
 ### Summary plots
 
-The summary plots below represent a calculated average for each type of the 
-clustering metrics, cluster purity and silhouette width, across each of the 
-parameters tested.
-Again, robust clusters should yield high cluster purity values and large positive
-silhouette width values.
+The summary plots below represent a calculated average for each type of the clustering metrics, cluster purity and silhouette width, across each of the parameters tested.
+Again, robust clusters should yield high cluster purity values and large positive silhouette width values.
 
 ```{r}
 # Set number of rows for plotting and use this to define figure widths
@@ -233,16 +215,11 @@ plot_avg_validity_stats(summary_validity_stats_df, "avg_width") +
 
 ## Plot cluster stability
 
-The plots below represent the stability of the clustering results associated 
-with each of the clustering parameters.
-Here, cells within each dataset are sampled using bootstrapping and the sampled
-cells are re-clustered. 
-The new clustering assignments are compared to the original assignment by
-obtaining an adjusted rand index, and this process is repeated 20 times.
-Clustering results with high stability would reveal that clustering after each 
-bootstrap replicate is consistent with the original clustering results.
-We use summary adjusted Rand Index (ARI) values in the plots below to represent 
-the average calculated cluster stability values.
+The plots below represent the stability of the clustering results associated with each of the clustering parameters.
+Here, cells within each dataset are sampled using bootstrapping and the sampled cells are re-clustered. 
+The new clustering assignments are compared to the original assignment by obtaining an adjusted rand index, and this process is repeated 20 times.
+Clustering results with high stability would reveal that clustering after each bootstrap replicate is consistent with the original clustering results.
+We use summary adjusted Rand Index (ARI) values in the plots below to represent the average calculated cluster stability values.
 The range here is `0` to `1`, where stable clusters have values closer to 1.
 
 ```{r}

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -21,8 +21,10 @@ output:
     code_folding: hide
 ---
 
-This notebook will look at additional clustering parameters on the expression of
-the genes in a single sample of the dataset of interest, from an unbiased approach.
+This notebook will plot the output of the 
+`optional-clustering-analysis/clustering-calculations.R` script, which allows 
+for additional clustering parameters to be calculated on the expression of the 
+genes in a single sample of the dataset of interest.
 
 ## Set Up
 
@@ -128,7 +130,8 @@ summary_stability_stats_df <- summary_stability_stats_df %>%
 
 ## UMAP plot results for `r params$library`
 
-Below is a UMAP plot where each cell has been colored based on the cell's cluster assignment. 
+Below is a UMAP plot for each clustering parameter, where each cell has been 
+colored based on the cell's cluster assignment. 
 Here clustering was performed using `r params$cluster_type` clustering.
 
 ```{r}
@@ -156,7 +159,17 @@ cowplot::plot_grid(plotlist = plot_list, ncol = num_col)
 
 ## Plot cluster validity stats
 
+Below are plots that display the validity results of each of the cluster assignments.
+
 #### Purity plots
+
+The purity plots below represent each cell as the proportion of neighboring 
+cells that are assigned to the same cluster.
+Well-separated clusters should show little over-lapping between member and 
+neighboring cells, and therefore high purity values for all member cells.
+The cluster purity range is `0` to `1`, therefore purity values that are
+consistently greater than `0.9` indicate that most cells in each cluster are 
+primarily surrounded by other cells belonging to the same cluster.
 
 ```{r}
 # Plot individual cluster purity stats
@@ -167,6 +180,16 @@ purity_plots + theme(text = element_text(size = 12), legend.text = element_text(
 
 #### Silhouette width plots
 
+The silhouette width plots below represent how well-separated each of the 
+clusters are.
+For each cell, the average distance to all cells in the same cluster and the 
+average distance to all cells in another cluster, are calculated. 
+The silhouette width for each cell is defined as the difference between these 
+two values divided by their maximum.
+Therefore, cells will ideally have large positive silhouette widths, as this 
+would mean that the cells of one cluster are well-separated from other clusters.
+The silhouette width range is `-1` to `1`.
+
 ```{r}
 # Plot individual cluster silhouette width stats
 silhouette_plots <- plot_cluster_silhouette_width(all_validity_stats_df, num_col)
@@ -175,6 +198,12 @@ silhouette_plots + theme(text = element_text(size = 12), legend.text = element_t
 ```
 
 ### Summary plots
+
+The summary plots below represent a calculated average for each type of cluster 
+validity statistic, cluster purity and silhouette width, across each of the 
+cluster parameters.
+Again, ideally you would expect high cluster purity values and large positive
+silhouette width values.
 
 ```{r}
 # Set number of rows for plotting and use this to define figure widths
@@ -198,6 +227,16 @@ plot_avg_validity_stats(summary_validity_stats_df, "avg_width") +
 ```
 
 ## Plot cluster stability
+
+The plots below represent how stable the clustering results associated with each
+of the clustering parameters appear to be when using bootstrap replicates.
+Ideally, bootstrap replicates would be highly consistent with the original 
+dataset, as this would mean that clusters are likely to be stable despite small 
+changes to upstream processing and overall would mean that they can be reproduced.
+We use summary adjusted Rand Index (ARI) values in the plots below to represent 
+the average calculated cluster stability values.
+The range here is `0` to `1`, where clusters would ideally have ARI values that
+are closer to 1, as this would mean greater cluster stability.
 
 ```{r}
 # Grab the cluster stability stats summary data frame

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -23,8 +23,8 @@ output:
 
 This notebook will plot the output of the 
 `optional-clustering-analysis/clustering-calculations.R` script, which allows 
-for additional clustering parameters to be calculated on gene expression data 
-associated with a single sample of the dataset of interest.
+for additional types of clustering across a range of parameters to be calculated
+on gene expression data associated with a single sample of the dataset of interest.
 
 ## Set Up
 
@@ -130,8 +130,9 @@ summary_stability_stats_df <- summary_stability_stats_df %>%
 
 ## UMAP plot results for `r params$library`
 
-Below is a UMAP plot for each clustering parameter, where each cell has been 
-colored based on the cell's cluster assignment. 
+Below is a set of UMAP plots, where each panel corresponds to clustering 
+performed with a given clustering parameter and each cell is colored based on
+the cell's cluster assignment. 
 Here clustering was performed using `r params$cluster_type` clustering.
 
 ```{r}
@@ -157,17 +158,21 @@ plot_list <- existing_columns %>%
 cowplot::plot_grid(plotlist = plot_list, ncol = num_col)
 ```
 
-## Plot cluster validity stats
+## Evaluating clustering
 
-Below are plots that display the validity results of each of the cluster assignments.
+Below we evaluate the clustering results across each of the parameters tested. 
+We will look at the cluster purity, silhouette width, and cluster stability for 
+each clustering type and nearest neighbors value used.
+For a more in depth discussion on these metrics and how they can be used to 
+identify the optimal clustering results, see the [advanced clustering chapter in Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.15/OSCA.advanced/clustering-redux.html#motivation).
 
 #### Purity plots
 
 The purity plots below represent each cell as the proportion of neighboring 
 cells that are assigned to the same cluster.
-Well-separated clusters should show little over-lapping between member and 
+Well-separated clusters should show little overlap between member and 
 neighboring cells, and therefore high purity values for all member cells.
-The cluster purity range is `0` to `1`, therefore purity values that are
+The cluster purity range is `0` to `1`. Therefore purity values that are
 consistently greater than `0.9` indicate that most cells in each cluster are 
 primarily surrounded by other cells belonging to the same cluster.
 
@@ -199,10 +204,10 @@ silhouette_plots + theme(text = element_text(size = 12), legend.text = element_t
 
 ### Summary plots
 
-The summary plots below represent a calculated average for each type of cluster 
-validity statistic, cluster purity and silhouette width, across each of the 
-cluster parameters.
-Again, ideally you would expect high cluster purity values and large positive
+The summary plots below represent a calculated average for each type of the 
+clustering metrics, cluster purity and silhouette width, across each of the 
+parameters tested.
+Again, robust clusters should yield high cluster purity values and large positive
 silhouette width values.
 
 ```{r}
@@ -228,15 +233,17 @@ plot_avg_validity_stats(summary_validity_stats_df, "avg_width") +
 
 ## Plot cluster stability
 
-The plots below represent how stable the clustering results associated with each
-of the clustering parameters appear to be when using bootstrap replicates.
-Ideally, bootstrap replicates would be highly consistent with the original 
-dataset, as this would mean that clusters are likely to be stable despite small 
-changes to upstream processing and overall would mean that they can be reproduced.
+The plots below represent the stability of the clustering results associated 
+with each of the clustering parameters.
+Here, cells within each dataset are sampled using bootstrapping and the sampled
+cells are re-clustered. 
+The new clustering assignments are compared to the original assignment by
+obtaining an adjusted rand index, and this process is repeated 20 times.
+Clustering results with high stability would reveal that clustering after each 
+bootstrap replicate is consistent with the original clustering results.
 We use summary adjusted Rand Index (ARI) values in the plots below to represent 
 the average calculated cluster stability values.
-The range here is `0` to `1`, where clusters would ideally have ARI values that
-are closer to 1, as this would mean greater cluster stability.
+The range here is `0` to `1`, where stable clusters have values closer to 1.
 
 ```{r}
 # Grab the cluster stability stats summary data frame

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -23,8 +23,8 @@ output:
 
 This notebook will plot the output of the 
 `optional-clustering-analysis/clustering-calculations.R` script, which allows 
-for additional clustering parameters to be calculated on the expression of the 
-genes in a single sample of the dataset of interest.
+for additional clustering parameters to be calculated on gene expression data 
+associated with a single sample of the dataset of interest.
 
 ## Set Up
 


### PR DESCRIPTION
**Issue Addressed**
Closes #206

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
As mentioned on the relevant issue, we want to add some general documentation to the optional clustering template notebook (being added in PR #207), that would help folks interpret their resulting plots.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR is stacked on the branch in #207 to add documentation to the beginning of the notebook, as well as to the beginning of each of the plotting sections.
Documentation added includes what each of the plots represent and the expected/ideal range of values for each of the plots.

**Any comments, concerns, or questions important for reviewers**
- Does this added documentation seem to sufficiently address #206?
- Is the documentation added clear? Should there be additional docs added anywhere here?

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)