### PR TITLE
Initialize optional clustering directory README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ conda activate snakemake
 
 ### 3) Additional dependencies
 
-To run the Snakemake workflow, you will need to have R version 4.1 installed, as well as the `renv` package and pandoc.
+To run the Snakemake workflow, you will need to have R version 4.2 installed, as well as the `renv` package and pandoc.
 This can be done independently, or you can use Snakemake's conda integration to set up an R environment that the workflow will use.
 
 

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -1,10 +1,10 @@
 # Optional Clustering Analysis
 
-This directory includes a clustering analysis workflow that can be implemented after users have successfully ran the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file.
+This directory includes a clustering analysis workflow that can help users identify the optimal clustering method and parameters for each library in their dataset. 
+Libraries are unique, which means that the optimal clustering is likely to be library-dependent.
+The clustering analysis workflow provided here can be used to explore different methods of clustering and test a range of parameter values for a given clustering method in order to identify the optimal clustering for each library.
 
-The clustering analysis workflow can be used to explore different types of clustering and test a range of parameter values for a given type of clustering.
-Libraries are unique, which means that the optimal clustering is going to be library-dependent.
-Exploring clustering types and parameters can be helpful in choosing the optimal clustering for each library.
+**The clustering analysis workflow cannot be implemented until after users have successfully run the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file.**
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -22,7 +22,8 @@ There are two main steps of this clustering analysis workflow:
 
 1. **Cluster Calculations**: clustering results are calculated for the provided type of graph-based clustering, and range of nearest neighbor values.
 Cluster validity and stability results are also calculated.
-2. **Cluster Plots**: once clustering results are calculated and stored in the `SingleCellExperiment` object, each of the results are associated with UMAP plots, as well as cluster validity and stability plots to represent the reliability of each set of clustering results.
+2. **Cluster Plots**: once clustering results are calculated and stored in the `SingleCellExperiment` object, the results from each of the clustering methods tested are displayed in a UMAP plot.
+Additionally, metrics associated with each of the clustering results such as silhouette width, cluster purity, and cluster stability are calculated and plotted.
 The plots are displayed in a html report for ease of reference.
 
 **Note** that the same [software requirements for the core workflow](https://github.com/AlexsLemonade/scpca-downstream-analyses/tree/development#3-additional-dependencies) are also required for this clustering workflow.

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -2,6 +2,22 @@
 
 This directory includes a clustering analysis workflow that can be implemented after users have successfully ran the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file.
 
+The clustering analysis workflow can be used to explore different types of clustering and test a range of parameter values for a given type of clustering.
+Libraries are unique, which means that the optimal clustering is going to be library-dependent.
+Exploring clustering types and parameters can be helpful in choosing the optimal clustering for each library.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Analysis overview](#analysis-overview)
+- [Expected input](#expected-input)
+- [Expected output](#expected-output)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Analysis overview
+
 There are two main steps of this clustering analysis workflow:
 
 1. **Cluster Calculations**: clustering results are calculated for the provided type of graph-based clustering, and range of nearest neighbor values.
@@ -9,39 +25,31 @@ Cluster validity and stability results are also calculated.
 2. **Cluster Plots**: once clustering results are calculated and stored in the `SingleCellExperiment` object, each of the results are associated with UMAP plots, as well as cluster validity and stability plots to represent the reliability of each set of clustering results.
 The plots are displayed in a html report for ease of reference.
 
-**Note** that the same software requirements for the core workflow are also required for this clustering workflow.
+**Note** that the same [software requirements for the core workflow](https://github.com/AlexsLemonade/scpca-downstream-analyses/tree/development#3-additional-dependencies) are also required for this clustering workflow.
 R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
-Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), and `renv` must be installed locally prior to running the workflow.
+Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which must be installed locally prior to running the workflow.
 If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
-
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**
-
-- [Expected input](#expected-input)
-- [Expected output](#expected-output)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Expected input
 
 To run this workflow, you will need to provide:
 
-1. The [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow.
+1. The RDS file containing the [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow.
+2. The [`library_id`](../README.md#metadata-file-format) associated with the `SingleCellExperiment` object.
 2. The desired type of graph-based clustering (can be "louvain" or "walktrap"), along with the minimum, maximum, and incremental values that will be used to define the range of nearest neighbor values to be tested.
-For example, if you would like a range of 5:25 to be tested in increments of 5 (5, 10, 15, 20, 25), you will provide `nearest_neighbors_min` = 5, `nearest_neighbors_max` = 25, and `nearest_neighbors_increment` = 5.
+For example, if you would like a range of `5:25` to be tested in increments of 5 (as in, `5, 10, 15, 20, 25`), you will provide `nearest_neighbors_min` = 5, `nearest_neighbors_max` = 25, and `nearest_neighbors_increment` = 5.
 
 ## Expected output
 
-For each `SingleCellExperiment` RDS file and associated `library_id` used as input, the workflow will return five files:
+For each provided `SingleCellExperiment` RDS file and associated `library_id`, the workflow will return five files in the same directory where the inputted RDS file is stored:
 
 1. The `SingleCellExperiment` RDS file containing the added clustering results that were calculated in the first step of the worflow.
-2. The summary html report with the plots representing the clustering results.
+2. The `_optional_clustering_report.html` file, which is the summary html report with plots containing the clustering results.
 3. A `_clustering_all_validity_stats.tsv` file with all of the calculated cluster validity statistics.
 4. A `_clustering_summary_validity_stats.tsv` file with the cluster validity stats averaged across each cluster assignment.
 5. A `_clustering_summary_stability_stats.tsv` file with the average adjusted Rand Index (ARI) values across each cluster assignment.
 
-The latter three files described above will be found in a `clustering_stats` subdirectory stored in the same results directory where the `SingleCellExperiment` RDS file is stored.
+The TSV files will be saved in a subdirectory called `clustering_stats/`.
  
 
 

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -1,0 +1,47 @@
+# Optional Clustering Analysis
+
+This directory includes a clustering analysis workflow that can be implemented after users have successfully ran the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file.
+
+There are two main steps of this clustering analysis workflow:
+
+1. **Cluster Calculations**: clustering results are calculated for the provided type of graph-based clustering, and range of nearest neighbor values.
+Cluster validity and stability results are also calculated.
+2. **Cluster Plots**: once clustering results are calculated and stored in the `SingleCellExperiment` object, each of the results are associated with UMAP plots, as well as cluster validity and stability plots to represent the reliability of each set of clustering results.
+The plots are displayed in a html report for ease of reference.
+
+**Note** that the same software requirements for the core workflow are also required for this clustering workflow.
+R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
+Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), and `renv` must be installed locally prior to running the workflow.
+If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Expected input](#expected-input)
+- [Expected output](#expected-output)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Expected input
+
+To run this workflow, you will need to provide:
+
+1. The [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow.
+2. The desired type of graph-based clustering (can be "louvain" or "walktrap"), along with the minimum, maximum, and incremental values that will be used to define the range of nearest neighbor values to be tested.
+For example, if you would like a range of 5:25 to be tested in increments of 5 (5, 10, 15, 20, 25), you will provide `nearest_neighbors_min` = 5, `nearest_neighbors_max` = 25, and `nearest_neighbors_increment` = 5.
+
+## Expected output
+
+For each `SingleCellExperiment` RDS file and associated `library_id` used as input, the workflow will return five files:
+
+1. The `SingleCellExperiment` RDS file containing the added clustering results that were calculated in the first step of the worflow.
+2. The summary html report with the plots representing the clustering results.
+3. A `_clustering_all_validity_stats.tsv` file with all of the calculated cluster validity statistics.
+4. A `_clustering_summary_validity_stats.tsv` file with the cluster validity stats averaged across each cluster assignment.
+5. A `_clustering_summary_stability_stats.tsv` file with the average adjusted Rand Index (ARI) values across each cluster assignment.
+
+The latter three files described above will be found in a `clustering_stats` subdirectory stored in the same results directory where the `SingleCellExperiment` RDS file is stored.
+ 
+
+


### PR DESCRIPTION
**Issue Addressed**
Closes #181 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Now that we have an `optional-clustering-analysis` module, we want to have a `README.md` file that lives within this module/sub-directory to document what's happening within the module.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR adds an `optional-clustering-analysis/README.md` file which begins to document what's in the optional clustering module, the steps of the workflow, the expected input, and the expected output. When we get around to initializing the `Snakefile`, I imagine these sections being fleshed out a bit more, specifically the expected input/output sections.

**Any comments, concerns, or questions important for reviewers**
- Does the documentation in this PR appear to adequately satisfy #181?
- Can you think of any additional details that may be beneficial to add here at this time?

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)