### PR TITLE
Fix restore argument to use input lockfile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -44,7 +44,7 @@ rule build_renv:
     shell:
       """
       R_PROFILE_USER='{workflow.basedir}/.Rprofile' \
-      Rscript -e "renv::restore('{input}')"
+      Rscript -e "renv::restore(lockfile = '{input}')"
       date -u -Iseconds  > {output}
       """
 


### PR DESCRIPTION
In https://github.com/AlexsLemonade/sc-data-integration/pull/136#issuecomment-1242485543, I noticed that the lockfile was mis-specified in the `build_renv` rule, which seems to make rebuilding when the `renv.lock` file changes fail with the statement that the lock file is up to date. This fixes the arguments, and should hopefully make updating work the way it was expected to.