### PR TITLE
Pin pandoc version

### DIFF
--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - cmake
   - geos
-  - pandoc
+  - pandoc=2.18
   - pkg-config
   - openssl
   - r-base=4.2.1


### PR DESCRIPTION
This is a small PR to avoid a potential problem where a version of pandoc (2.19.1) is broken resulting in bad rendering of Rmd files.

Note that this will require rebuilding the renv environment, which can now be done with `bash setup_envs.sh` (or `./setup_envs.sh` if you want to save keystrokes).