### PR TITLE
Add logs to snakemake rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # ignore the `data`, `results`, and `example-results` directories and the files within
-/data/
-/results/
-/example-results/
+data/
+results/
+example-results/
+logs/
 
 # ignore hidden `DS_Store`
 .DS_Store

--- a/cluster.snakefile
+++ b/cluster.snakefile
@@ -34,18 +34,18 @@ rule target:
                zip,
                sample = SAMPLES,
                library = LIBRARY_ID,
-               filter_method = FILTERING_METHOD)       
+               filter_method = FILTERING_METHOD)
 
 rule calculate_clustering:
     input:
-        "{basedir}/{sample_id}/{library_id}_{filter_method}_processed_sce.rds"
+        "{basedir}/{library_id}_{filter_method}_processed_sce.rds"
     output:
-        sce = "{basedir}/{sample_id}/{library_id}_{filter_method}_clustered_sce.rds",
-        stats_dir = directory("{basedir}/{sample_id}/{library_id}_{filter_method}_clustering_stats")
+        sce = "{basedir}/{library_id}_{filter_method}_clustered_sce.rds",
+        stats_dir = directory("{basedir}/{library_id}_{filter_method}_clustering_stats")
+    log: "logs/{basedir}/{library_id}_{filter_method}/calculate_clustering.log"
     conda: "envs/scpca-renv.yaml"
     shell:
-        "R_PROFILE_USER='{workflow.basedir}/.Rprofile'"
-        " Rscript '{workflow.basedir}/optional-clustering-analysis/clustering-calculations.R'"
+        " Rscript 'optional-clustering-analysis/clustering-calculations.R'"
         "  --sce {input}"
         "  --library_id {wildcards.library_id}"
         "  --cluster_type {config[cluster_type]}"
@@ -55,21 +55,22 @@ rule calculate_clustering:
         "  --nearest_neighbors_min {config[nearest_neighbors_min]}"
         "  --nearest_neighbors_max {config[nearest_neighbors_max]}"
         "  --nearest_neighbors_increment {config[nearest_neighbors_increment]}"
-        "  --project_root {workflow.basedir}"
+        "  --project_root $PWD"
         "  --overwrite {config[overwrite_results]}"
-        
+        " &> {log}"
+
 rule generate_cluster_report:
     input:
-        processed_sce = "{basedir}/{sample_id}/{library_id}_{filter_method}_clustered_sce.rds",
-        stats_dir = "{basedir}/{sample_id}/{library_id}_{filter_method}_clustering_stats"
+        processed_sce = "{basedir}/{library_id}_{filter_method}_clustered_sce.rds",
+        stats_dir = "{basedir}/{library_id}_{filter_method}_clustering_stats"
     output:
-        "{basedir}/{sample_id}/{library_id}_{filter_method}_clustering_report.html"
+        "{basedir}/{library_id}_{filter_method}_clustering_report.html"
+    log: "{basedir}/{library_id}_{filter_method}/cluster_report.log"
     conda: "envs/scpca-renv.yaml"
     shell:
         """
-        R_PROFILE_USER='{workflow.basedir}/.Rprofile' \
         Rscript -e \
-        "rmarkdown::render('{workflow.basedir}/optional-clustering-analysis/clustering-report-template.Rmd', \
+        "rmarkdown::render('optional-clustering-analysis/clustering-report-template.Rmd', \
                            clean = TRUE, \
                            output_file = '{output}', \
                            output_dir = dirname('{output}'), \
@@ -80,5 +81,6 @@ rule generate_cluster_report:
                                          nearest_neighbors_min = {config[nearest_neighbors_min]}, \
                                          nearest_neighbors_max = {config[nearest_neighbors_max]}, \
                                          nearest_neighbors_increment = {config[nearest_neighbors_increment]}), \
-                           envir = new.env())"
+                           envir = new.env())" \
+        &> {log}
         """


### PR DESCRIPTION
**Issue Addressed**
N/A

**What is the purpose of these changes?**

This PR adds `log:` directives to the Snakefiles in this repository. I originally was prompted to do this because I rand `snakemake --lint` as an thought for testing, and saw that this was recommended, and it comes with a few advantages: it should make debugging rules a bit easier, as the logs are now written to files rather than just the screen, and this also means that the screen output is _only_ snakemake rules, which saves a bit of random text & prevents multiple jobs from writing to the screen at once.


**What changes did you make?**
The primary change is adding the `log:` directive to all rules, which will store files in the `logs/` directory, arranged similarly to the input data. The log file path has to include all wildcards, hence the nested directory structure. I could alternatively have made very long names for the log files, but I thought nesting was just as easy. Happy to reconsider this though.

Each rule also adds a line for outputting stdout and stderr to the log file, usually in the form `&> {log}`.

I also did some cleanup removing no longer needed references to `{workflow.basedir}` and `.Rprofile` as those should now be covered by always running the workflows from the main project directory. 

**Were there any other solutions that you tried?**
Not really: just whether to change the output paths, but doing it another way would mean breaking up some of the `{basedir}` wildcards, which seemed like trouble.

**Any comments, concerns, or questions important for reviewers**

`snakemake --lint` also complains about using the config settings directly in shell commands. It would prefer that they be defined as `params` and used that way. I decided not to do that here, as it adds a lot of boilerplate, and doesn't give as obvious a benefit for debugging/cleaner screens.

Info about logs should probably be added to the docs, but I don't think great detail is needed.

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)