### PR TITLE
Account for additional `cluster_type` in clustering report

### DIFF
--- a/cluster.snakefile
+++ b/cluster.snakefile
@@ -78,7 +78,7 @@ rule generate_cluster_report:
                            params = list(library = '{wildcards.library_id}', \
                                          processed_sce = '{input.processed_sce}', \
                                          stats_dir = '{input.stats_dir}', \
-                                         cluster_type = '{config[core_cluster_type]}', \
+                                         cluster_type = '{config[optional_cluster_types]}', \
                                          nearest_neighbors_min = {config[nearest_neighbors_min]}, \
                                          nearest_neighbors_max = {config[nearest_neighbors_max]}, \
                                          nearest_neighbors_increment = {config[nearest_neighbors_increment]}), \

--- a/optional-clustering-analysis/clustering-calculations.R
+++ b/optional-clustering-analysis/clustering-calculations.R
@@ -178,7 +178,7 @@ nn_range <- define_nn_range(opt$nearest_neighbors_min,
 
 perform_clustering <- function(sce, nn_range, cluster_type, ...) {
   # Check for existing clustering results
-  cluster_column_names <- paste(cluster_type, nn_range, sep = "_")
+  cluster_column_names <- sprintf("%s_%02d", cluster_type, nn_range)
   existing_columns <-
     intersect(cluster_column_names, colnames(colData(sce)))
   

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -165,17 +165,25 @@ knitr::opts_chunk$set(
 
 ```{r}
 # Plot UMAP coordinates
-plot_list <- existing_columns %>%
-  purrr::map(
-    ~ plotReducedDim(processed_sce, dimred = "UMAP",colour_by = .x,
-                     point_size = 0.4, point_alpha = 0.5) +
-      theme_bw() +
-      theme(text = element_text(size = 14),
-            legend.text = element_text(size = 14)) +
-      guides(color = guide_legend(override.aes = list(size = 1)))
-  )
-
-cowplot::plot_grid(plotlist = plot_list, ncol = num_col)
+for (cluster_type in cluster_types) {
+  existing_columns_filtered <- existing_columns[stringr::str_detect(existing_columns, cluster_type)]
+  plot_list <- existing_columns_filtered %>%
+    purrr::map(
+      ~ plotReducedDim(
+        processed_sce,
+        dimred = "UMAP",
+        colour_by = .x,
+        point_size = 0.4,
+        point_alpha = 0.5
+      ) +
+        theme_bw() +
+        theme(text = element_text(size = 14),
+              legend.text = element_text(size = 14)) +
+        guides(color = guide_legend(override.aes = list(size = 1)))
+    )
+  
+  cowplot::plot_grid(plotlist = plot_list, ncol = num_col)
+}
 ```
 
 ## Evaluating clustering

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -64,10 +64,13 @@ library(ggpubr)
 library(scater)
 library(dplyr)
 
+# Split up string of cluster types
+cluster_types <- unlist(stringr::str_split(params$cluster_type, ","))
+
 # Set theme for plotting
 library(ggplot2)
-theme_set(theme_bw() + theme(text = element_text(size = 17),
-                             legend.text = element_text(size = 16)))
+theme_set(theme_bw() + theme(text = element_text(size = 17*length(cluster_types)),
+                             legend.text = element_text(size = 16*length(cluster_types))))
 point_size <- params$point_size
 ```
 
@@ -83,9 +86,6 @@ nn_range <- define_nn_range(params$nearest_neighbors_min,
                             params$nearest_neighbors_increment)
 
 cluster_column_names <- c()
-
-# Split up string of cluster types
-cluster_types <- unlist(stringr::str_split(params$cluster_type, ","))
 
 # Grab column name with clustering results
 for (cluster_type in cluster_types) {
@@ -154,8 +154,13 @@ Here clustering was performed using `r params$cluster_type` clustering.
 ```{r}
 # Set number of columns for plotting and use this to define figure heights 
 # and widths
-num_col <- 2
-figure_dim <- max(ceiling(length(existing_columns)/num_col) * 5, 4)
+if (length(cluster_types) == 1) {
+  num_col <- 2
+} else {
+  num_col <- length(cluster_types)
+}
+
+figure_dim <- max(ceiling(length(existing_columns)/num_col) * length(existing_columns)/num_col + 2, (length(existing_columns)/num_col) + 1)
 
 knitr::opts_chunk$set(
   fig.height = figure_dim,
@@ -170,12 +175,12 @@ plot_list <- existing_columns %>%
     ~ plotReducedDim(processed_sce, dimred = "UMAP",colour_by = .x,
                      point_size = 0.4, point_alpha = 0.5) +
       theme_bw() +
-      theme(text = element_text(size = 14),
-            legend.text = element_text(size = 14)) +
+      theme(text = element_text(size = length(existing_columns)*length(cluster_types) - 1),
+            legend.text = element_text(size = length(existing_columns)*length(cluster_types) - 1)) +
       guides(color = guide_legend(override.aes = list(size = 1)))
   )
 
-cowplot::plot_grid(plotlist = plot_list, ncol = num_col)
+cowplot::plot_grid(plotlist = plot_list, ncol = num_col, byrow = FALSE)
 ```
 
 ## Evaluating clustering

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -149,7 +149,11 @@ summary_stability_stats_df <- summary_stability_stats_df %>%
 ## UMAP plot results for `r params$library`
 
 Below is a set of UMAP plots, where each panel corresponds to clustering performed with a given clustering parameter and each cell is colored based on the cell's cluster assignment.
-Here clustering was performed using `r params$cluster_type` clustering.
+Here clustering was performed using the following clustering types:
+
+```{r results='asis'}
+cat(paste("-", cluster_types), sep = "\n")
+```
 
 ```{r}
 # Set number of columns for plotting and use this to define figure heights 

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -25,6 +25,14 @@ editor_options:
 ---
 
 This notebook will plot the output of the `optional-clustering-analysis/clustering-calculations.R` script, which allows for additional types of clustering across a range of parameters to be calculated on gene expression data associated with a single sample of the dataset of interest.
+Here clustering was performed using the following clustering types:
+
+```{r results='asis'}
+# Split up string of cluster types
+cluster_types <- unlist(stringr::str_split(params$cluster_type, ","))
+
+cat(paste("-", cluster_types), sep = "\n")
+```
 
 ## Set Up
 
@@ -63,9 +71,6 @@ library(miQC)
 library(ggpubr)
 library(scater)
 library(dplyr)
-
-# Split up string of cluster types
-cluster_types <- unlist(stringr::str_split(params$cluster_type, ","))
 
 # Set theme for plotting
 library(ggplot2)
@@ -149,11 +154,6 @@ summary_stability_stats_df <- summary_stability_stats_df %>%
 ## UMAP plot results for `r params$library`
 
 Below is a set of UMAP plots, where each panel corresponds to clustering performed with a given clustering parameter and each cell is colored based on the cell's cluster assignment.
-Here clustering was performed using the following clustering types:
-
-```{r results='asis'}
-cat(paste("-", cluster_types), sep = "\n")
-```
 
 ```{r}
 # Set number of columns for plotting and use this to define figure heights 

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -1,9 +1,9 @@
 ---
 params:
   library: "library01"
-  processed_sce: "example-results/sample01/library01_processed_sce_clustering.rds"
-  stats_dir: "example-results/sample01/clustering_stats"
-  cluster_type: "louvain"
+  processed_sce: "example-results/sample01/library01_miQC_clustered_sce.rds"
+  stats_dir: "example-results/sample01/library01_miQC_clustering_stats"
+  cluster_type: "louvain,walktrap"
   nearest_neighbors_min: 5
   nearest_neighbors_max: 25
   nearest_neighbors_increment: 5
@@ -82,9 +82,17 @@ nn_range <- define_nn_range(params$nearest_neighbors_min,
                             params$nearest_neighbors_max,
                             params$nearest_neighbors_increment)
 
+cluster_column_names <- c()
+
+# Split up string of cluster types
+cluster_types <- unlist(stringr::str_split(params$cluster_type, ","))
+
 # Grab column name with clustering results
-cluster_column_names <- paste(params$cluster_type, nn_range, sep = "_")
-existing_columns <- intersect(cluster_column_names, colnames(colData(processed_sce)))
+for (cluster_type in cluster_types) {
+  cluster_column_names <- c(cluster_column_names, sprintf("%s_%02d", cluster_type, nn_range))
+}
+
+existing_columns <-intersect(cluster_column_names, colnames(colData(processed_sce)))
 
 # Check length of `existing_columns`
 if(length(existing_columns) == 0){

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -177,10 +177,17 @@ plot_list <- existing_columns %>%
       theme_bw() +
       theme(text = element_text(size = length(existing_columns)*length(cluster_types) - 1),
             legend.text = element_text(size = length(existing_columns)*length(cluster_types) - 1)) +
-      guides(color = guide_legend(override.aes = list(size = 1)))
+      guides(color = guide_legend(override.aes = list(size = 4)))
   )
 
-cowplot::plot_grid(plotlist = plot_list, ncol = num_col, byrow = FALSE)
+cowplot::plot_grid(
+  plotlist = plot_list,
+  ncol = num_col,
+  byrow = FALSE,
+  labels = cluster_types,
+  label_size = 30,
+  vjust = 0
+) + theme(plot.margin = unit(c(1, 1, 10, 1), "cm"))
 ```
 
 ## Evaluating clustering
@@ -198,7 +205,7 @@ The cluster purity range is `0` to `1`. Therefore purity values that are consist
 ```{r}
 # Plot individual cluster purity stats
 purity_plots <- plot_cluster_purity(all_validity_stats_df, num_col, point_size) + 
-  guides(color = guide_legend(override.aes = list(size = 1)))
+  guides(color = guide_legend(override.aes = list(size = 5)))
 
 purity_plots
 ```

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -165,25 +165,17 @@ knitr::opts_chunk$set(
 
 ```{r}
 # Plot UMAP coordinates
-for (cluster_type in cluster_types) {
-  existing_columns_filtered <- existing_columns[stringr::str_detect(existing_columns, cluster_type)]
-  plot_list <- existing_columns_filtered %>%
-    purrr::map(
-      ~ plotReducedDim(
-        processed_sce,
-        dimred = "UMAP",
-        colour_by = .x,
-        point_size = 0.4,
-        point_alpha = 0.5
-      ) +
-        theme_bw() +
-        theme(text = element_text(size = 14),
-              legend.text = element_text(size = 14)) +
-        guides(color = guide_legend(override.aes = list(size = 1)))
-    )
-  
-  cowplot::plot_grid(plotlist = plot_list, ncol = num_col)
-}
+plot_list <- existing_columns %>%
+  purrr::map(
+    ~ plotReducedDim(processed_sce, dimred = "UMAP",colour_by = .x,
+                     point_size = 0.4, point_alpha = 0.5) +
+      theme_bw() +
+      theme(text = element_text(size = 14),
+            legend.text = element_text(size = 14)) +
+      guides(color = guide_legend(override.aes = list(size = 1)))
+  )
+
+cowplot::plot_grid(plotlist = plot_list, ncol = num_col)
 ```
 
 ## Evaluating clustering

--- a/optional-clustering-analysis/clustering-report-template.Rmd
+++ b/optional-clustering-analysis/clustering-report-template.Rmd
@@ -177,7 +177,7 @@ plot_list <- existing_columns %>%
       theme_bw() +
       theme(text = element_text(size = length(existing_columns)*length(cluster_types) - 1),
             legend.text = element_text(size = length(existing_columns)*length(cluster_types) - 1)) +
-      guides(color = guide_legend(override.aes = list(size = 4)))
+      guides(color = guide_legend(override.aes = list(size = length(cluster_types))))
   )
 
 cowplot::plot_grid(
@@ -185,7 +185,7 @@ cowplot::plot_grid(
   ncol = num_col,
   byrow = FALSE,
   labels = cluster_types,
-  label_size = 30,
+  label_size = 15*length(cluster_types),
   vjust = 0
 ) + theme(plot.margin = unit(c(1, 1, 10, 1), "cm"))
 ```

--- a/utils/clustering-functions.R
+++ b/utils/clustering-functions.R
@@ -545,7 +545,7 @@ plot_cluster_stability_ari <- function(ari_plotting_df, point_size = 0.7) {
     ggforce::geom_sina(size = point_size) +
     stat_summary(
       aes(group = param_value),
-      color = "red",
+      color = "black",
       # median and quartiles for point range
       fun = "median",
       fun.min = function(x) {
@@ -564,45 +564,4 @@ plot_cluster_stability_ari <- function(ari_plotting_df, point_size = 0.7) {
     facet_wrap( ~ cluster_type)
   
   return(plot)
-}
-
-plot_summary_cluster_stability_ari <- function(ari_df_list) {
-  # Purpose: Calculate a summary data frame of the provided cluster
-  # stability ARI values and return a plot displaying these summary values
-  
-  # Args:
-  #   ari_df_list: list of data frames with cluster stability ARI values 
-  #                associated with their relevant clustering type and param values
-  
-  # prepare a data frame for plotting
-  ari_combined_df <- dplyr::bind_rows(ari_df_list)
-  
-  # create a summary data.frame of the results across the individual clusters
-  ari_summary_df <- ari_combined_df %>%
-    dplyr::group_by(cluster_names_column, cluster_type, param_value) %>%
-    # here we calculate and store the median of the ARI values along with the
-    # median absolute deviation (MAD) values
-    dplyr::summarize(median_ARI = median(ARI),
-                     mad_ARI = mad(ARI),
-                     .groups = 'drop')
-
-  
-  # plot the summary ARI values
-  ari_summary_plot <- ggplot(
-    ari_summary_df,
-    aes(
-      x = param_value,
-      y = median_ARI,
-      color = cluster_type)) +
-    geom_pointrange(aes(x = param_value, y = median_ARI, 
-                        ymin = median_ARI - mad_ARI,
-                        ymax = median_ARI + mad_ARI),
-                    color = "black",
-                    position = position_dodge2(width = 0.6)) +
-    geom_line() +
-    labs(x = "Parameter value",
-         y = "Median ARI",
-         color = "Cluster type")
-  
-  return(ari_summary_plot)
 }

--- a/utils/clustering-functions.R
+++ b/utils/clustering-functions.R
@@ -466,7 +466,8 @@ plot_avg_validity_stats <- function(cluster_validity_summary_df_list,
     ylim(y_range) + 
     labs(x = "Parameter value",
          y = gsub("_", " ", measure),
-         color = "Cluster type")
+         color = "Cluster type") +
+    guides(color = guide_legend(override.aes = list(size = 5)))
   
   return(summary_plot)
 }

--- a/utils/clustering-functions.R
+++ b/utils/clustering-functions.R
@@ -558,7 +558,8 @@ plot_cluster_stability_ari <- function(ari_plotting_df, point_size = 0.7) {
       size = 0.2
     ) +
     scale_x_discrete(name = "Parameter value",
-                     limits = params_range)
+                     limits = params_range) +
+    facet_wrap( ~ cluster_type)
   
   return(plot)
 }

--- a/utils/clustering-functions.R
+++ b/utils/clustering-functions.R
@@ -540,7 +540,7 @@ plot_cluster_stability_ari <- function(ari_plotting_df, point_size = 0.7) {
   params_range <- sort(unique(ari_plotting_df$param_value))
   
   plot <-
-    ggplot(ari_plotting_df, aes(x = param_value, y = ARI, group = param_value)) +
+    ggplot(ari_plotting_df, aes(x = param_value, y = ARI, group = param_value, fill = cluster_type)) +
     geom_violin() +
     ggforce::geom_sina(size = point_size) +
     stat_summary(
@@ -556,7 +556,8 @@ plot_cluster_stability_ari <- function(ari_plotting_df, point_size = 0.7) {
       },
       geom = "pointrange",
       position = position_dodge(width = 0.9),
-      size = 0.2
+      size = 0.8,
+      shape = 21
     ) +
     scale_x_discrete(name = "Parameter value",
                      limits = params_range) +

--- a/utils/clustering-functions.R
+++ b/utils/clustering-functions.R
@@ -392,7 +392,7 @@ plot_cluster_silhouette_width <- function(cluster_validity_df, num_col, point_si
     ggbeeswarm::geom_quasirandom(method = "pseudorandom", size = point_size) +
     geom_hline(yintercept = 0, linetype = 'dotted') +
     labs(x = "Cluster Assignment") +
-    facet_wrap( ~ cluster_names_column, scale="free_x", ncol = num_col) +
+    facet_wrap( ~ cluster_names_column, scale="free_x", ncol = num_col, dir = "v") +
     stat_summary(
       aes(group = cluster_param_assignment),
       color = "red",

--- a/utils/clustering-functions.R
+++ b/utils/clustering-functions.R
@@ -141,7 +141,7 @@ graph_clustering <- function(normalized_sce,
   # perform the graph-based clustering
   for (nearest_neighbors in nn_range) {
     # set cluster name
-    cluster_name <- paste(cluster_type, nearest_neighbors, sep = "_")
+    cluster_name <- sprintf("%s_%02d", cluster_type, nearest_neighbors)
     
     # set the seed for reproducible results
     set.seed(seed)
@@ -273,7 +273,7 @@ create_metadata_stats_df <- function(clustered_sce, params_range, cluster_type) 
   #                 "walktrap", or "louvain"
   
   # define cluster names
-  cluster_names_column <- paste(cluster_type, params_range, sep = "_")
+  cluster_names_column <- sprintf("%s_%02d", cluster_type, params_range)
   
   # save data.frame to the cluster validity list of data.frames
   cluster_validity_df_list <- cluster_names_column %>% 
@@ -361,10 +361,9 @@ plot_cluster_purity <- function(cluster_validity_df, num_col, point_size = 0.7) 
       position = position_dodge(width = 0.9),
       size = 0.2
     ) +
-    labs(title = unique(metadata$cluster_type),
-         x = "Cluster Assignment",
+    labs(x = "Cluster Assignment",
          color = legend_title) +
-    facet_wrap( ~ param_value, scale="free", ncol = num_col)
+    facet_wrap( ~ cluster_names_column, scale="free_x", ncol = num_col, dir = "v")
   
   return(plot)
 }
@@ -392,9 +391,8 @@ plot_cluster_silhouette_width <- function(cluster_validity_df, num_col, point_si
     ggplot(metadata, aes(x = cluster, y = width)) +
     ggbeeswarm::geom_quasirandom(method = "pseudorandom", size = point_size) +
     geom_hline(yintercept = 0, linetype = 'dotted') +
-    labs(title = unique(metadata$cluster_type),
-         x = "Cluster Assignment") +
-    facet_wrap( ~ param_value, scale="free_x", ncol = num_col) +
+    labs(x = "Cluster Assignment") +
+    facet_wrap( ~ cluster_names_column, scale="free_x", ncol = num_col) +
     stat_summary(
       aes(group = cluster_param_assignment),
       color = "red",
@@ -491,9 +489,9 @@ get_cluster_stability_summary <- function(normalized_sce,
   
   # define cluster names
   if (cluster_type == "kmeans") {
-    cluster_names <- paste(cluster_type, params_range, sep = "_")
+    cluster_names <- sprintf("%s_%02d", cluster_type, params_range)
   } else if (cluster_type %in% c("walktrap", "louvain")) {
-    cluster_names <- paste(cluster_type, params_range, sep = "_")
+    cluster_names <- sprintf("%s_%02d", cluster_type, params_range)
   }
   
   ari_results <- list()


### PR DESCRIPTION
**Issue Addressed**
Closes #217

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Now that the modification that allows for more than one type of clustering has been made to the clustering calculations script in PR #224, we want to account for the additional cluster type in the clustering report template notebook as well.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR does the following:
- implements `sprintf()` where we create the cluster column names to fix the order of plots when displayed
- adds a for loop to the `clustering-report-template.Rmd` file to loop through a possible comma-separated list of more than one cluster type
- modifies the underlying plotting functions in `clustering-functions.R` to allow for plotting of more than one cluster type

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->

**Any comments, concerns, or questions important for reviewers**
- Does this PR seem to satisfy #217?
- Any suggestions on how the plots, comparing the parameters for each cluster type, should be displayed?

See an example html report with the changes made in this PR for reference:
[library01_miQC_clustering_report.html.zip](https://github.com/AlexsLemonade/scpca-downstream-analyses/files/9748258/library01_miQC_clustering_report.html.zip)

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)