### PR TITLE
Fix typos in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Future development will include addition of optional workflows for extended data
 The core workflow takes as input the gene expression data for each library being processed and performs the following steps:
 
 1. [Filtering](./processing-information.md#filtering-low-quality-cells): Each library is filtered to remove any low quality cells.
-Here filtering and removal of low quality cells can be performed using [`miQC::filterCells()`](https://rdrr.io/github/greenelab/miQC/man/filterCells.html) or through setting a series of manual thresholds (e.g. minimum number of UMI counts).
+Here filtering and removal of low quality cells can be performed using [`miQC::filterCells()`](https://rdrr.io/github/greenelab/miQC/man/filterCells.html) or through setting a series of manual thresholds (e.g., minimum number of UMI counts).
 In addition to removing low quality cells, genes found in a low percentage of cells in a library are removed.
 2. [Normalization](./processing-information.md#normalization) and [dimensionality reduction](./processing-information.md#dimensionality-reduction): Cells are normalized using the [deconvolution method from Lun, Bach, and Marioni (2016)](https://doi.org/10.1186/s13059-016-0947-7) and reduced dimensions are calculated using both principal component analysis (PCA) and uniform manifold approximation and projection (UMAP).
 Normalized log counts and embeddings from PCA and UMAP are stored in the `SingleCellExperiment` object returned by the workflow.
@@ -135,7 +135,7 @@ To create the necessary environment, which includes an isolated version of R, pa
 bash setup_envs.sh
 ```
 
-This script will use Snakemake to install all necessary components for the workflow in an isoloated Conda enviroment.
+This script will use Snakemake to install all necessary components for the workflow in an isolated enviroment.
 If you are on an Apple Silicon (M1/M2/Arm) Mac, this should properly handle setting up R to use an Intel-based build for compatibiity with Bioconductor packages.
 
 This installation may take up to an hour, as all of the R packages will likely have to be compiled from scratch.
@@ -178,8 +178,8 @@ If you need to take these steps, you may need to restart R/terminal to proceed w
 ## Input data format
 
 The expected input for our core single-cell downstream analysis pipeline is a [`SingleCellExperiment` object](https://rdrr.io/bioc/SingleCellExperiment/man/SingleCellExperiment.html) that has been stored as a RDS file.
-This`SingleCellExperiment` object should contain non-normalized gene expression data with barcodes as the column names and gene identifiers as the row names.
-All barcodes included in the `SingleCellExperiment` object should correspond to droplets likely to contain cells and should not contain empty droplets (e.g. droplets with FDR < 0.01 calculated with [`DropletUtils::emptyDropsCellRanger()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/emptyDropsCellRanger.html).
+This `SingleCellExperiment` object should contain non-normalized gene expression data with barcodes as the column names and gene identifiers as the row names.
+All barcodes included in the `SingleCellExperiment` object should correspond to droplets likely to contain cells and should not contain empty droplets (e.g., droplets with FDR < 0.01 calculated with [`DropletUtils::emptyDropsCellRanger()`](https://rdrr.io/github/MarioniLab/DropletUtils/man/emptyDropsCellRanger.html)).
 The full path to each individual RDS file should be defined in the project metadata described in the following "How to run the pipeline" section.
 
 The pipeline in this repository is setup to process data available on the [Single-cell Pediatric Cancer Atlas portal](https://scpca.alexslemonade.org/) and output from the [scpca-nf workflow](https://github.com/AlexsLemonade/scpca-nf) where single-cell/single-nuclei gene expression data is mapped and quantified using [alevin-fry](https://alevin-fry.readthedocs.io/en/latest/).

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ To create the necessary environment, which includes an isolated version of R, pa
 bash setup_envs.sh
 ```
 
-This script will use Snakemake to install all necessary components for the workflow in an isolated enviroment.
+This script will use Snakemake to install all necessary components for the workflow in an isolated environment.
 If you are on an Apple Silicon (M1/M2/Arm) Mac, this should properly handle setting up R to use an Intel-based build for compatibiity with Bioconductor packages.
 
 This installation may take up to an hour, as all of the R packages will likely have to be compiled from scratch.


### PR DESCRIPTION
**Issue Addressed**
Partly addresses #227 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR fixes some typos found upon internal testing of the core workflow.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
More specifically, this PR includes some spacing and punctuation fixes including:

- "Conda enviroment" -> "environment" where necessary
- "e.g." -> "e.g.,"
- add the missing space between "This" and "SingleCellExperiment"
- add the missing parentheses after "DropletUtils::emptyDropsCellRanger()"

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->

**Any comments, concerns, or questions important for reviewers**

Please let me know if there are any additional changes that should be made here.

Once we get this PR merged into development, we will want to update PR #233 to prepare for the new release.

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)