### PR TITLE
Move filtering method to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ The file should contain the following columns:
 
 - `sample_id`, unique ID for each piece of tissue or sample that cells were obtained from,  all libraries that were sampled from the same piece of tissue should have the same `sample_id`.
 - `library_id`, unique ID used for each set of cells that has been prepped and sequenced separately.
-- `filtering_method`, the specified filtering method which can be one of "manual" or "miQC". For more information on choosing a filtering method, see [Filtering low quality cells](./processing-information.md#filtering-low-quality-cells) in the [processing information documentation](./processing-information.md).
 - `filepath`, the full path to the RDS file containing the pre-processed `SingleCellExperiment` object.
 Each library ID should have a unique `filepath`.
 
@@ -229,6 +228,7 @@ Below are the parameters required to run either of the filtering methods.
 | Parameter        | Description | Default value |
 |------------------|-------------|---------------|
 | `seed` | an integer to be used to set a seed for reproducibility when running the workflow | 2021 |
+| `filtering_method` | `filtering_method`, the specified filtering method which can be one of "miQC" or "manual". For more information on choosing a filtering method, see [Filtering low quality cells](./processing-information.md#filtering-low-quality-cells) in the [processing information documentation](./processing-information.md) | "miQC" |
 | `prob_compromised_cutoff` | the maximum probability of a cell being compromised as calculated by [miQC](https://bioconductor.org/packages/release/bioc/html/miQC.html), which is required when the `filtering_method` is set to `miQC` in the project metadata | 0.75 |
 | `gene_detected_row_cutoff` | the percent of cells a gene must be detected in; genes detected are filtered regardless of the `filtering_method` specified in the project metadata | 5 |
 | `gene_means_cutoff` | mean gene expression minimum threshold; mean gene expression is filtered regardless of the `filtering_method` specified in the project metadata | 0.1 |

--- a/Snakefile
+++ b/Snakefile
@@ -9,27 +9,23 @@ if os.path.exists(config['project_metadata']):
   # get a list of the sample and library ids
   SAMPLES = list(samples_information['sample_id'])
   LIBRARY_ID = list(samples_information['library_id'])
-  FILTERING_METHOD = list(samples_information['filtering_method'])
 else:
   # If the metadata file is missing, warn and fill with empty lists
   print(f"Warning: Project metadata file '{config['project_metadata']}' is missing.")
   samples_information = None
   SAMPLES = list()
   LIBRARY_ID = list()
-  FILTERING_METHOD = list()
 
 rule target:
     input:
-        expand(os.path.join(config["results_dir"], "{sample}/{library}_{filtering_method}_processed_sce.rds"),
+        expand(os.path.join(config["results_dir"], "{sample}/{library}_processed_sce.rds"),
                zip,
                sample = SAMPLES,
-               library = LIBRARY_ID,
-               filtering_method = FILTERING_METHOD),
-        expand(os.path.join(config["results_dir"], "{sample}/{library}_{filtering_method}_core_analysis_report.html"),
+               library = LIBRARY_ID),
+        expand(os.path.join(config["results_dir"], "{sample}/{library}_core_analysis_report.html"),
                zip,
                sample = SAMPLES,
-               library = LIBRARY_ID,
-               filtering_method = FILTERING_METHOD)
+               library = LIBRARY_ID)
 
 
 # Rule used for building conda & renv environment
@@ -53,8 +49,8 @@ rule filter_data:
     input:
         get_input_rds_files
     output:
-        temp("{basedir}/{sample_id}/{library_id}_{filtering_method}_filtered.rds")
-    log: "logs/{basedir}/{sample_id}/{library_id}_{filtering_method}/filter_data.log"
+        temp("{basedir}/{sample_id}/{library_id}_filtered.rds")
+    log: "logs/{basedir}/{sample_id}/{library_id}/filter_data.log"
     conda: "envs/scpca-renv.yaml"
     shell:
         " Rscript 'core-analysis/01-filter-sce.R'"
@@ -70,7 +66,7 @@ rule filter_data:
         "  --detected_gene_cutoff {config[detected_gene_cutoff]}"
         "  --umi_count_cutoff {config[umi_count_cutoff]}"
         "  --prob_compromised_cutoff {config[prob_compromised_cutoff]}"
-        "  --filtering_method {wildcards.filtering_method}"
+        "  --filtering_method {config[filtering_method]}"
         "  --project_root $PWD"
         "  &> {log}"
 
@@ -126,10 +122,10 @@ rule clustering:
 rule generate_report:
     input:
         pre_processed_sce = get_input_rds_files,
-        processed_sce =  "{basedir}/{sample_id}/{library_id}_{filtering_method}_processed_sce.rds"
+        processed_sce =  "{basedir}/{sample_id}/{library_id}_processed_sce.rds"
     output:
-        "{basedir}/{sample_id}/{library_id}_{filtering_method}_core_analysis_report.html"
-    log: "logs/{basedir}/{sample_id}/{library_id}_{filtering_method}/generate_report.log"
+        "{basedir}/{sample_id}/{library_id}_core_analysis_report.html"
+    log: "logs/{basedir}/{sample_id}/{library_id}/generate_report.log"
     conda: "envs/scpca-renv.yaml"
     shell:
         """

--- a/cluster.snakefile
+++ b/cluster.snakefile
@@ -10,40 +10,35 @@ if os.path.exists(config['project_metadata']):
   # get a list of the sample and library ids
   SAMPLES = list(samples_information['sample_id'])
   LIBRARY_ID = list(samples_information['library_id'])
-  FILTERING_METHOD = list(samples_information['filtering_method'])
 else:
   # If the metadata file is missing, warn and fill with empty lists
   print(f"Warning: Project metadata file '{config['clustering_project_metadata']}' is missing.")
   samples_information = None
   SAMPLES = list()
   LIBRARY_ID = list()
-  FILTERING_METHOD = list()
 
 rule target:
     input:
-        expand(os.path.join(config["results_dir"], "{sample}/{library}_{filter_method}_clustered_sce.rds"),
+        expand(os.path.join(config["results_dir"], "{sample}/{library}_clustered_sce.rds"),
                zip,
                sample = SAMPLES,
-               library = LIBRARY_ID,
-               filter_method = FILTERING_METHOD),
-        expand(os.path.join(config["results_dir"], "{sample}/{library}_{filter_method}_clustering_stats"),
+               library = LIBRARY_ID),
+        expand(os.path.join(config["results_dir"], "{sample}/{library}_clustering_stats"),
                zip,
                sample = SAMPLES,
-               library = LIBRARY_ID,
-               filter_method = FILTERING_METHOD),
-        expand(os.path.join(config["results_dir"], "{sample}/{library}_{filter_method}_clustering_report.html"),
+               library = LIBRARY_ID),
+        expand(os.path.join(config["results_dir"], "{sample}/{library}_clustering_report.html"),
                zip,
                sample = SAMPLES,
-               library = LIBRARY_ID,
-               filter_method = FILTERING_METHOD)
+               library = LIBRARY_ID)
 
 rule calculate_clustering:
     input:
-        "{basedir}/{library_id}_{filter_method}_processed_sce.rds"
+        "{basedir}/{library_id}_processed_sce.rds"
     output:
-        sce = "{basedir}/{library_id}_{filter_method}_clustered_sce.rds",
-        stats_dir = directory("{basedir}/{library_id}_{filter_method}_clustering_stats")
-    log: "logs/{basedir}/{library_id}_{filter_method}/calculate_clustering.log"
+        sce = "{basedir}/{library_id}_clustered_sce.rds",
+        stats_dir = directory("{basedir}/{library_id}_clustering_stats")
+    log: "logs/{basedir}/{library_id}/calculate_clustering.log"
     conda: "envs/scpca-renv.yaml"
     shell:
         " Rscript 'optional-clustering-analysis/clustering-calculations.R'"
@@ -62,11 +57,11 @@ rule calculate_clustering:
 
 rule generate_cluster_report:
     input:
-        processed_sce = "{basedir}/{library_id}_{filter_method}_clustered_sce.rds",
-        stats_dir = "{basedir}/{library_id}_{filter_method}_clustering_stats"
+        processed_sce = "{basedir}/{library_id}_clustered_sce.rds",
+        stats_dir = "{basedir}/{library_id}_clustering_stats"
     output:
-        "{basedir}/{library_id}_{filter_method}_clustering_report.html"
-    log: "{basedir}/{library_id}_{filter_method}/cluster_report.log"
+        "{basedir}/{library_id}_clustering_report.html"
+    log: "{basedir}/{library_id}/cluster_report.log"
     conda: "envs/scpca-renv.yaml"
     shell:
         """

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,7 +6,7 @@
 # file paths
 results_dir: "example-results"
 mito_file: "reference-files/Homo_sapiens.GRCh38.104.mitogenes.txt"
-project_metadata: "project-metadata/example-library-metadata.tsv"
+project_metadata: "example-data/project-metadata/example-library-metadata.tsv"
 
 ### Processing parameters
 # The below are parameters that are utilized to specify parameters specific to processing an individual library through the workflow.
@@ -17,6 +17,7 @@ project_metadata: "project-metadata/example-library-metadata.tsv"
 seed: 2021
 
 # miQC filtering parameters
+filtering_method: "miQC"
 prob_compromised_cutoff: 0.75 # Maximum miQC probability of cell being compromised
 
 # manual filtering parameters

--- a/example-data/project-metadata/example-library-metadata.tsv
+++ b/example-data/project-metadata/example-library-metadata.tsv
@@ -1,0 +1,3 @@
+sample_id	library_id	filepath
+sample01	library01	example-data/sample01/library01_filtered.rds
+sample02	library02	example-data/sample02/library02_filtered.rds

--- a/project-metadata/example-library-metadata.tsv
+++ b/project-metadata/example-library-metadata.tsv
@@ -1,3 +1,0 @@
-sample_id	library_id	filtering_method	filepath
-sample01	library01	miQC	example-data/sample01/library01_filtered.rds
-sample02	library02	miQC	example-data/sample02/library02_filtered.rds


### PR DESCRIPTION
**Issue Addressed**
Closes #243

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
The purpose of this PR is to move the filtering method from the metadata to the config file as it is no longer necessary in the metadata file now that we have a check that uses manual filtering if miQC fails.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR does the following:

- moves the filtering method "miQC" from the metadata file to the `config/config.yaml` file
- updates the `README.md` file to reflect this change
- updates the core Snakefile and the clustering Snakefile to reflect this change (I have tested that both run successfully with the new changes in this PR)
- moves the example project metadata file into `example-data` per issue #250

**Any comments, concerns, or questions important for reviewers**
- Does this PR seem to satisfy what is outlined on issue #243?

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)