### PR TITLE
Add section on core workflow output SCE contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,14 +313,18 @@ In the [`colData`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecell
 - Clustering results stored in a metadata column named using the associated clustering type and nearest neighbours values.
 For example, if using the default values of Louvain clustering with a nearest neighbors parameter of 10, the column name would be `louvain_10` and can be accessed using `colData(sce)$louvain_10`.
 
-In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#other-metadata) of the output `SingleCellExperiment` object, you can find the following information:
+In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#other-metadata) of the output `SingleCellExperiment` object, which can be accessed using `metadata(sce)` you can find the following information:
 
 | Metadata Information       | Description |
 |----------------------------|-------------|
-| Filtering method           | The type of filtering performed ([`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) or `manual`) on the expression data, which can be accessed using `metadata(sce)$filtering`. |
-| Filtering cutoffs          | The relevant filtering cutoffs. In the case of `miQC` filtering, the maximum probability of cells being compromised is stored and can be accessed using `metadata(sce)$probability_compromised_cutoff`. See the [filtering parameters section](#filtering-parameters) for more information on what filtering cutoffs to expect here. |
-| Clustering of similar cells for normalization | A note indicating whether or not clustering of similar cells passed the [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) step in the normalization script. If clustering of similar cells was successful, the note that reads "scater::logNormCounts clustered" can be found in `metadata(sce)$normalization`. |
-| Highly variable genes | The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html), can be accessed using `metadata(sce)$variable_genes`. |
+| `filtering_method`           | The type of filtering performed ([`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) or `manual`) on the expression data. |
+| `prob_compromised_cutoff` | The maximum probability of cells being compromised, which only present when the `filtering_method` is set to `miQC`. |
+| `miQC_model` | The linear mixture model calculated by `miQC` and therefore is only present when `filtering_method` is set to `miQC`. |
+| `mito_percent_cutoff` | Maximum percent mitochondrial reads per cell threshold, which is only present when `filtering_method` is set to `manual`. |
+| `detected_gene_cutoff` | Minimum number of genes detected per cell, which is only present when `filtering_method` is set to `manual`. |
+| `umi_count_cutoff` | Minimum unique molecular identifiers (UMI) per cell, which is only present when `filtering_method` is set to `manual`. |
+| `normalization` | Indicates if clustering of similar cells prior to normalization using [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) prior to normalization with `scater::logNormCounts()` was successful. |
+| `variable_genes` | The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html). |
 
 You can find more information on the above in the [processing information documentation](./additional-docs/processing-information.md).
 

--- a/README.md
+++ b/README.md
@@ -313,17 +313,17 @@ In the [`colData`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecell
 - Clustering results stored in a metadata column named using the associated clustering type and nearest neighbours values.
 For example, if using the default values of Louvain clustering with a nearest neighbors parameter of 10, the column name would be `louvain_10` and can be accessed using `colData(sce)$louvain_10`.
 
-In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#other-metadata) of the output `SingleCellExperiment` object, which can be accessed using `metadata(sce)` you can find the following information:
+In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#other-metadata) of the output `SingleCellExperiment` object, which can be accessed using `metadata(sce)`,  you can find the following information:
 
-| Metadata Information       | Description |
+| Metadata Key       | Description |
 |----------------------------|-------------|
 | `filtering_method`           | The type of filtering performed ([`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) or `manual`) on the expression data. |
-| `prob_compromised_cutoff` | The maximum probability of cells being compromised, which only present when the `filtering_method` is set to `miQC`. |
+| `prob_compromised_cutoff` | The maximum probability of cells being compromised, which is only present when the `filtering_method` is set to `miQC`. |
 | `miQC_model` | The linear mixture model calculated by `miQC` and therefore is only present when `filtering_method` is set to `miQC`. |
 | `mito_percent_cutoff` | Maximum percent mitochondrial reads per cell threshold, which is only present when `filtering_method` is set to `manual`. |
 | `detected_gene_cutoff` | Minimum number of genes detected per cell, which is only present when `filtering_method` is set to `manual`. |
 | `umi_count_cutoff` | Minimum unique molecular identifiers (UMI) per cell, which is only present when `filtering_method` is set to `manual`. |
-| `normalization` | Indicates if clustering of similar cells prior to normalization using [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) prior to normalization with `scater::logNormCounts()` was successful. |
+| `normalization` | Indicates if clustering of similar cells using [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) prior to normalization with `scater::logNormCounts()` was successful. |
 | `variable_genes` | The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html). |
 
 You can find more information on the above in the [processing information documentation](./additional-docs/processing-information.md).

--- a/README.md
+++ b/README.md
@@ -313,13 +313,12 @@ For example, if using the default values of Louvain clustering with a nearest ne
 
 In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#other-metadata) of the output `SingleCellExperiment` object, you can find the following information:
 
-- The type of filtering performed (`miQC` or `manual`) on the expression data, which can be accessed using `metadata(sce)$filtering`.
-- The relevant filtering cutoffs.
-In the case of [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) filtering, the maximum probability of cells being compromised is stored and can be accessed using `metadata(sce)$probability_compromised_cutoff`.
-See the [filtering parameters section](#filtering-parameters) for more information on what filtering cutoffs to expect here.
-- A note indicating whether or not clustering of similar cells passed the [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) step in the normalization script.
-If clustering of similar cells was successful, the note that reads "scater::logNormCounts clustered" can be found in `metadata(sce)$normalization`.
-- The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html), can be accessed using `metadata(sce)$variable_genes`
+| Metadata Information       | Description |
+|----------------------------|-------------|
+| Filtering method           | The type of filtering performed ([`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) or `manual`) on the expression data, which can be accessed using `metadata(sce)$filtering`. |
+| Filtering cutoffs          | The relevant filtering cutoffs. In the case of `miQC` filtering, the maximum probability of cells being compromised is stored and can be accessed using `metadata(sce)$probability_compromised_cutoff`. See the [filtering parameters section](#filtering-parameters) for more information on what filtering cutoffs to expect here. |
+| Clustering of similar cells for normalization | A note indicating whether or not clustering of similar cells passed the [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) step in the normalization script. If clustering of similar cells was successful, the note that reads "scater::logNormCounts clustered" can be found in `metadata(sce)$normalization`. |
+| Highly variable genes | The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html), can be accessed using `metadata(sce)$variable_genes`. |
 
 You can find more information on the above in the [processing information documentation](./additional-docs/processing-information.md).
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
     - [Filtering parameters](#filtering-parameters)
     - [Dimensionality reduction and clustering parameters](#dimensionality-reduction-and-clustering-parameters)
 - [Expected output](#expected-output)
+  - [What to expect in the output `SingleCellExperiment` object](#what-to-expect-in-the-output-singlecellexperiment-object)
 - [Additional analysis modules](#additional-analysis-modules)
   - [Clustering analysis](#clustering-analysis)
   - [The optional genes of interest analysis pipeline (In development)](#the-optional-genes-of-interest-analysis-pipeline-in-development)

--- a/README.md
+++ b/README.md
@@ -291,12 +291,30 @@ example_results
 	 └── <library_id>_<filtering_method>_processed_sce.rds
 ```
 
+The `<library_id>_<filtering_method>_core_analysis_report.html` file is the [html file](https://bookdown.org/yihui/rmarkdown/html-document.html#html-document) that contains the summary report of the filtering, dimensionality reduction, and clustering results associated with the processed `SingleCellExperiment` object.
+
 The `<library_id>_<filtering_method>_processed_sce.rds` file is the [RDS file](https://rstudio-education.github.io/hopr/dataio.html#saving-r-files) that contains the final processed `SingleCellExperiment` object (which contains the filtered, normalized data and clustering results).
-Clustering results can be found in the [`colData`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#handling-metadata) of the `SingleCellExperiment` object, stored in a metadata column named using the associated clustering type and nearest neighbours values.
+
+### What to expect in the output `SingleCellExperiment` object
+
+As a result of the normalization step of the workflow, a log-transformed normalized expression matrix can be accessed using [`logcounts(sce)`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#adding-more-assays).
+
+In the [`colData`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#handling-metadata) of the output `SingleCellExperiment` object, you can find the following:
+
+- Clustering results stored in a metadata column named using the associated clustering type and nearest neighbours values.
 For example, if using the default values of Louvain clustering with a nearest neighbors parameter of 10, the column name would be `louvain_10` and can be accessed using `colData(sce)$louvain_10`.
 
+In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#other-metadata) of the output `SingleCellExperiment` object, you can find the following information:
 
-The `<library_id>_<filtering_method>_core_analysis_report.html` file is the [html file](https://bookdown.org/yihui/rmarkdown/html-document.html#html-document) that contains the summary report of the filtering, dimensionality reduction, and clustering results associated with the processed `SingleCellExperiment` object.
+- The type of filtering performed (`miQC` or `manual`) on the expression data, which can be accessed using `metadata(sce)$filtering`.
+- The relevant filtering cutoffs.
+In the case of [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) filtering, the maximum probability of cells being compromised is stored and can be accessed using `metadata(sce)$probability_compromised_cutoff`.
+See the [filtering parameters section](#filtering-parameters) for more information on what filtering cutoffs to expect here.
+- A note indicating whether or not clustering of similar cells passed the [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) step in the normalization script.
+If clustering of similar cells was successful, the note that reads "scater::logNormCounts clustered" can be found in `metadata(sce)$normalization`.
+- The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html), can be accessed using `metadata(sce)$variable_genes`
+
+You can find more information on the above in the [processing information documentation](./additional-docs/processing-information.md).
 
 ## Additional analysis modules
 


### PR DESCRIPTION
**Issue Addressed**
Closes #237 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR adds a subsection named `What to expect in the output SingleCellExperiment object` under the already existing `Expected Output` in the main `README.md` file.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
In the added subsection, details around what is added to the SingleCellExperiment object and stored in the output .rds file are given.
More specifically, this includes information around the following:
- what is in the `logcounts` assay
- what is added to the `colData` of the SCE object, including default clustering results
- what is added to the `metadata` of the SCE object, including filtering type, cutoffs, and a note regarding normalization

**Any comments, concerns, or questions important for reviewers**
- Are the descriptions suffice for this use case?
- Do you have any suggestions on additional information that maybe should be added to this subsection?

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)