### PR TITLE
Add UMAP plot labels in core workflow

### DIFF
--- a/core-analysis/core-analysis-report-template.Rmd
+++ b/core-analysis/core-analysis-report-template.Rmd
@@ -205,9 +205,9 @@ plotReducedDim(
   dimred = "UMAP",
   colour_by = cluster_name,
   text_by = cluster_name,
-  text_size = 3,
+  text_size = 4,
   point_size = 0.4,
-  point_alpha = 0.2
+  point_alpha = 0.5
 ) +
   theme_bw() +
   labs(
@@ -217,7 +217,7 @@ plotReducedDim(
       params$nearest_neighbors
     )
   ) +
-  guides(col = guide_legend("Cluster assignment", override.aes = list(size = 5))) +
+  guides(col = guide_legend("Cluster assignment", override.aes = list(size = 3))) +
   theme(text = element_text(size = 14),
         plot.caption = element_text(hjust = 0.5))
 ```

--- a/core-analysis/core-analysis-report-template.Rmd
+++ b/core-analysis/core-analysis-report-template.Rmd
@@ -217,7 +217,7 @@ plotReducedDim(
       params$nearest_neighbors
     )
   ) +
-  guides(col = guide_legend("Cluster assignment")) +
+  guides(col = guide_legend("Cluster assignment", override.aes = list(size = 5))) +
   theme(text = element_text(size = 14),
         plot.caption = element_text(hjust = 0.5))
 ```

--- a/core-analysis/core-analysis-report-template.Rmd
+++ b/core-analysis/core-analysis-report-template.Rmd
@@ -200,12 +200,23 @@ Here clustering was performed using `r params$cluster_type` clustering with a ne
 cluster_name <- paste(params$cluster_type, params$nearest_neighbors, sep = "_")
 
 # Plot
-plotReducedDim(processed_sce, dimred = "UMAP", colour_by = cluster_name) +
+plotReducedDim(
+  processed_sce,
+  dimred = "UMAP",
+  colour_by = cluster_name,
+  text_by = cluster_name,
+  text_size = 3,
+  point_size = 0.4,
+  point_alpha = 0.2
+) +
   theme_bw() +
   labs(
-    caption = paste0(stringr::str_to_title(params$cluster_type),
-                     " clustering with nearest neighbors value ",
-                     params$nearest_neighbors)) +
+    caption = paste0(
+      stringr::str_to_title(params$cluster_type),
+      " clustering with nearest neighbors value ",
+      params$nearest_neighbors
+    )
+  ) +
   guides(col = guide_legend("Cluster assignment")) +
   theme(text = element_text(size = 14),
         plot.caption = element_text(hjust = 0.5))


### PR DESCRIPTION
**Issue Addressed**
Closes #242

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Per issue #242, this PR adds cluster assignment labels to the UMAP plot in the core analysis workflow, and adjusts the point size and transparency.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR modifies the `core-analysis/core-analysis-report-template.Rmd` to add text labels to the UMAP plot displaying each of the cluster assignments.
In the same function, the point sizes and transparency are slightly adjusted.

**Any comments, concerns, or questions important for reviewers**

Here is the an example of the updated report for reference: 
[library01_core_analysis_report.html.zip](https://github.com/AlexsLemonade/scpca-downstream-analyses/files/10189123/library01_core_analysis_report.html.zip)

And the outdated report for comparison:
[library01_core_analysis_report_outdated.html.zip](https://github.com/AlexsLemonade/scpca-downstream-analyses/files/10189127/library01_core_analysis_report_outdated.html.zip)

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)