### PR TITLE
Add number of filtered cells to metadata of SCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecel
 | `mito_percent_cutoff` | Maximum percent mitochondrial reads per cell threshold, which is only present when `filtering_method` is set to `manual`. |
 | `detected_gene_cutoff` | Minimum number of genes detected per cell, which is only present when `filtering_method` is set to `manual`. |
 | `umi_count_cutoff` | Minimum unique molecular identifiers (UMI) per cell, which is only present when `filtering_method` is set to `manual`. |
-| `num_filtered_cells_retained` | The number of cells retained after filtering. |
+| `num_filtered_cells_retained` | The number of cells retained after filtering using the specified filtering method, either `miQC` or `manual`. |
 | `normalization` | Indicates if clustering of similar cells using [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) prior to normalization with `scater::logNormCounts()` was successful. |
 | `variable_genes` | The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html). |
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecel
 | `mito_percent_cutoff` | Maximum percent mitochondrial reads per cell threshold, which is only present when `filtering_method` is set to `manual`. |
 | `detected_gene_cutoff` | Minimum number of genes detected per cell, which is only present when `filtering_method` is set to `manual`. |
 | `umi_count_cutoff` | Minimum unique molecular identifiers (UMI) per cell, which is only present when `filtering_method` is set to `manual`. |
+| `num_filtered_cells_retained` | The number of cells retained after filtering. |
 | `normalization` | Indicates if clustering of similar cells using [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) prior to normalization with `scater::logNormCounts()` was successful. |
 | `variable_genes` | The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html). |
 

--- a/core-analysis/01-filter-sce.R
+++ b/core-analysis/01-filter-sce.R
@@ -248,9 +248,11 @@ detected <-
 expressed <- rowData(filtered_sce)$mean > opt$gene_means_cutoff
 filtered_sce <- filtered_sce[detected & expressed, ]
 
-# Save sample and library id in metadata of filtered object
+# Save sample, library id, and number of cells retained after filtering in 
+# metadata of filtered object
 metadata(filtered_sce)$sample <- opt$sample_id
 metadata(filtered_sce)$library <- opt$library_id
+metadata(filtered_sce)$num_filtered_cells_retained <- dim(filtered_sce)[2]
 
 # Save output filtered sce
 readr::write_rds(filtered_sce, output_file)

--- a/core-analysis/core-analysis-report-template.Rmd
+++ b/core-analysis/core-analysis-report-template.Rmd
@@ -80,7 +80,7 @@ processed_meta <- metadata(processed_sce)
 
 # Define number of cells
 num_cells_pre_processed <- dim(pre_processed_sce)[2]
-num_filtered_cells <- dim(processed_sce)[2]
+num_filtered_cells <- processed_meta$num_filtered_cells_retained
 
 # Define sample id
 if(is.null(processed_meta$sample)){


### PR DESCRIPTION
**Issue Addressed**
Closes #245

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Per #245, it would be nice to have the number of cells retained after filtering saved to the metadata of the SCE object for reference and future use.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR adds a line to the `01-filter-sce.R` script to save the number of cells retained after filtering to the metadata of the filtered object.
This PR also modifies the `core-analysis-report-template.Rmd` to use this added metadata field to display the number of cells after filtering.

**Any comments, concerns, or questions important for reviewers**
Let me know if you believe anything else should be covered in this PR!

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)