### PR TITLE
Fix how we handle annotation when gene set is NULL

### DIFF
--- a/optional-goi-analysis/goi-calculations.R
+++ b/optional-goi-analysis/goi-calculations.R
@@ -292,8 +292,7 @@ if(!is.null(goi_list$gene_set)) {
         goi_rownames_column,
         "gene_id"
       )
-  } 
-  column_annotation <- NULL
+  }
 }
 
 # Convert heatmap matrix to a sparse matrix and save to file
@@ -304,8 +303,11 @@ Matrix::writeMM(normalized_zscores_matrix,
             paste0(opt$library_id, "_normalized_zscores.mtx")
           ))
 
-# Save heatmap column annotation to file
-write_rds(column_annotation, file.path(
-  opt$output_directory,
-  paste0(opt$library_id, "_heatmap_annotation.rds")
-))
+if(exists("column_annotation")) {
+  # Save heatmap column annotation to file
+  write_rds(column_annotation,
+            file.path(
+              opt$output_directory,
+              paste0(opt$library_id, "_heatmap_annotation.rds")
+            ))
+}

--- a/optional-goi-analysis/goi-report-template.Rmd
+++ b/optional-goi-analysis/goi-report-template.Rmd
@@ -73,11 +73,15 @@ heatmap_matrix <- Matrix::readMM(file.path(
 # Convert to standard matrix for heatmap plotting
 heatmap_matrix <- as.matrix(heatmap_matrix)
 
-column_annotation <- read_rds(file.path(
-  project_root,
-  params$goi_input_directory,
-  paste0(params$library, "_heatmap_annotation.rds")
-))
+if(!is.null(goi_list$gene_set)) {
+  heatmap_annotation <- read_rds(file.path(
+    project_root,
+    params$goi_input_directory,
+    paste0(params$library, "_heatmap_annotation.rds")
+  ))
+} else {
+  heatmap_annotation <- NULL
+}
 ```
 
 ```{r results='asis'}
@@ -115,7 +119,7 @@ Heatmap(heatmap_matrix,
         clustering_method_columns = "average",
         show_row_names = FALSE,
         show_column_names = TRUE,
-        top_annotation = column_annotation,
+        top_annotation = heatmap_annotation,
         name = "z score")
 ```
 


### PR DESCRIPTION
**Issue Addressed**
Closes #267 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR fixes how we handle the heatmap column annotation when `gene_set` is NULL. Instead of saving an empty column annotation file at the end of the GOI calculations script, this PR adds in a few checks to only save the file if gene set and therefore a column annotation exists.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
The `goi-calculations.R` script was modified to only save a column annotation file if column annotation exists as a result of the gene set logic.
The `goi-report-template.Rmd` notebook was modified to check if a `gene_set` column exists in the mapped goi list and only reads in a column annotation file if it does.
Noting that if it doesn't, heatmap_annotation is set to NULL in the notebook as to have something to provide to the heatmap plotting function. I did this to avoid having an if statement where there heatmap plotting function is copied and pasted without the annotation argument, but please let me know if you feel this would be better suited here!

**Any comments, concerns, or questions important for reviewers**
Does this PR seem to address #267? 
Do you have any ideas for further refactoring?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)