### PR TITLE
Add overwrite option to GOI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
   - [What to expect in the output `SingleCellExperiment` object](#what-to-expect-in-the-output-singlecellexperiment-object)
 - [Additional analysis modules](#additional-analysis-modules)
   - [Clustering analysis](#clustering-analysis)
-  - [The optional genes of interest analysis pipeline (In development)](#the-optional-genes-of-interest-analysis-pipeline-in-development)
+  - [Genes of interest analysis](#genes-of-interest-analysis)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -345,21 +345,9 @@ The clustering analysis workflow provided can be used to explore different metho
 
 For more on what's in the clustering analysis workflow and how to run the workflow, see the [`README.md`](optional-clustering-analysis/README.md#optional-clustering-analysis) file in the clustering analysis subdirectory.
 
-### The optional genes of interest analysis pipeline (In development)
-
-Note that this module is still **in development**, updates will be coming soon.
+### Genes of interest analysis
 
 There is an optional genes of interest analysis pipeline in the `optional-goi-analysis` subdirectory of this repository.
+This workflow can help users evaluate expression of a specific list of genes in their sample dataset and how the expression values compare to the remaining genes in the dataset.
 
-To run this analysis, you can run the following command from the main directory:
-
-```
-bash optional-goi-analysis/run-provided-goi-analysis.sh \
- --output_dir "path/to/output-results" \
- --sample_name "sample"  \
- --sample_matrix "path/to/sample/matrix" \
- --sample_metadata "path/to/sample/metadata" \
- --goi_list "path/to/goi-list"
-```
-
-Where `goi_list` is the path to the genes of interest TSV file relevant to your dataset.
+For more on what's in the genes of interest analysis workflow and how to run the workflow, see the [`README.md`](optional-goi-analysis/README.md#optional-clustering-analysis) file in the genes of interest analysis subdirectory.

--- a/config/goi_config.yaml
+++ b/config/goi_config.yaml
@@ -7,3 +7,4 @@ provided_identifier: "SYMBOL" # The type of gene identifiers used to populate th
 sce_rownames_identifier: "ENSEMBL" # The type of gene identifiers found in the rownames of the SingleCellExperiment object
 multi_mappings: "list" # How to handle multiple gene identifier mappings
 perform_mapping: TRUE # A binary value indicating whether or not to perform gene identifier mapping
+overwrite: TRUE # A binary value indicating whether or not to overwrite any existing output files

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -117,7 +117,7 @@ The parameters found in the `config/goi_config.yaml` file can be optionally modi
 | `sce_rownames_identifier` | the type of gene identifiers found in the rownames of the SingleCellExperiment object | "ENSEMBL" |
 | `perform_mapping` | a binary value indicating whether or not to perform gene identifier mapping | `TRUE` |
 | `multi_mappings` | how to handle multiple gene identifier mappings when `perform_mapping` is `TRUE` | "list" |
-| `overwrite` | a binary value indicating whether or not to overwrite any existing output files | `TRUE` |
+| `overwrite` | a binary value indicating whether or not to overwrite existing output files | `TRUE` |
 
 
 |[View Genes of Interest Config File](../config/goi_config.yaml)|

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -10,7 +10,11 @@ This directory includes a genes of interest analysis workflow to help users eval
 **Table of Contents**
 
 - [Analysis overview](#analysis-overview)
+- [Running the workflow](#running-the-workflow)
 - [Expected input](#expected-input)
+- [Parameters and config file](#parameters-and-config-file)
+  - [Project-specific parameters](#project-specific-parameters)
+  - [Genes of Interest parameters](#genes-of-interest-parameters)
 - [Expected output](#expected-output)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -33,6 +37,27 @@ R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
 Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which must be installed locally prior to running the workflow.
 If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
 
+## Running the workflow
+
+The execution file with the genes of interest Snakemake workflow is named `goi.snakefile` and can be found in the root directory.
+To tell snakemake to run the specific genes of interest workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `goi.snakefile`.
+The below code is an example of running the genes of interest workflow.
+
+```
+snakemake --snakefile goi.snakefile \ 
+  --cores 2 \
+  --use-conda \
+  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>"
+```
+
+**You will want to replace the paths for both `results_dir` and `project_metadata` to successfully run the workflow.** 
+Where `results_dir` is the relative path to the results directory where all results from running the workflow will be stored and `project_metadata` is the relative path to the TSV file containing the relevant information about your input files.
+See more information on project metadata in the [expected input section](#expected-input) below.
+
+**Note:**  If you did not install dependencies [with conda via snakemake](../README.md#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
+
+
 ## Expected input
 
 To run this workflow, you will need to provide:
@@ -43,20 +68,73 @@ This `SingleCellExperiment` object must contain a log-normalized counts matrix i
 3. The genes of interest list, stored as a tab-separated value (TSV) file.
 This file should contain at least one column named `gene_id` with the relevant gene identifiers, and can optionally contain an additional column named `gene_set` that denotes the gene set that each gene identifier belongs to (see an example of this genes of interest file [here](../example-data/goi-lists/sample01_goi_list.tsv)).
 
+## Parameters and config file
+
+As in the main core workflow, we have provided a [configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html), `config/config.yaml` which sets the defaults for project-specific parameters needed to run the genes of interest workflow.
+
+### Project-specific parameters
+
+There are a set of parameters included in the `config/config.yaml` file that will need to be specified when running the workflow.
+These parameters are specific to the project or dataset being processed.
+These include the following parameters:
+
+| Parameter        | Description |
+|------------------|-------------|
+| `results_dir` | relative path to the directory where output files will be stored (use the same `results_dir` used in the prerequisite core workflow) |
+| `project_metadata` | relative path to your specific project metadata TSV file (use the same `project_metadata` used in the prerequisite core workflow) |
+
+|[View Config File](../config/config.yaml)|
+|---|
+
+The above parameters can be modified at the command line by using the [`--config` flag](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html).
+You must also specify the number of CPU cores for snakemake to use by using the [`--cores` flag](https://snakemake.readthedocs.io/en/stable/tutorial/advanced.html?highlight=cores#step-1-specifying-the-number-of-used-threads).
+If `--cores` is given without a number, all available cores are used to run the workflow.
+If you installed dependencies for the workflow [with conda via snakemake](../README.md#snakemakeconda-installation), you will need to provide the `--use_conda` flag as well.
+
+The below code is an example of running the genes of interest workflow using the project-specific parameters.
+
+```
+snakemake --snakefile goi.snakefile \ 
+  --cores 2 \
+  --use-conda \
+  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>"
+```
+
+
+### Genes of Interest parameters
+
+We have provided an additional [configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html), `config/goi_config.yaml` which sets the defaults for all parameters needed to run the clustering workflow.
+It is **not required** to alter these parameters to run the workflow, but if you would like to change the type of clustering or range of nearest neighbor parameters, you can do so by changing these parameters. 
+
+The parameters found in the `config/goi_config.yaml` file can be optionally modified and are as follows:
+
+| Parameter        | Description | Default value |
+|------------------|-------------|---------------|
+| `goi_list` | the file path to a tsv file containing the list of genes that are of interest | `example-data/goi-lists/example_goi_list.tsv` |
+| `organism` | the organism associated with the provided genes and data | "Homo sapiens" |
+| `provided_identifier` | the type of gene identifiers used to populate the genes of interest list | "SYMBOL" |
+| `sce_rownames_identifier` | the type of gene identifiers found in the rownames of the SingleCellExperiment object | "ENSEMBL" |
+| `perform_mapping` | a binary value indicating whether or not to perform gene identifier mapping | `TRUE` |
+| `multi_mappings` | how to handle multiple gene identifier mappings when `perform_mapping` is `TRUE` | "list" |
+
+
+|[View Genes of Interest Config File](../config/goi_config.yaml)|
+|---|
+
 ## Expected output
 
 For each provided `SingleCellExperiment` RDS file and associated `library_id`, the workflow will return the following files in the specified output directory:
 
 ```
-goi_stats
-├── library01_mapped_genes.tsv
-├── library01_normalized_zscores.mtx
-├── library01_heatmap_annotation.rds
-└── library01_goi-report.html
+{library_id}_goi_report.html
+{library_id}_goi_stats
+├── {library_id}_mapped_genes.tsv
+├── {library_id}_normalized_zscores.mtx
+└── {library_id}_heatmap_annotation.rds
 ```
 
 1. A `_mapped_genes.tsv` file with mapped genes of interest if the `--perform_mapping` is `TRUE` upon running the workflow. Otherwise this file will store just the provided genes of interest, and a new column named `sce_rownames_identifier` with the genes of interest identifiers copied over to the column.
 2. A `_normalized_zscores.mtx` matrix file with the z-scored matrix calculated using the normalized data specific to the provided genes of interest.
 3. A `_heatmap_annotation.rds` file with the annotations to be used when plotting the heatmap for the html report.
 4. The `_goi_report.html` file, which is the summary html report with plots containing the GOI results.
-

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -117,6 +117,7 @@ The parameters found in the `config/goi_config.yaml` file can be optionally modi
 | `sce_rownames_identifier` | the type of gene identifiers found in the rownames of the SingleCellExperiment object | "ENSEMBL" |
 | `perform_mapping` | a binary value indicating whether or not to perform gene identifier mapping | `TRUE` |
 | `multi_mappings` | how to handle multiple gene identifier mappings when `perform_mapping` is `TRUE` | "list" |
+| `overwrite` | a binary value indicating whether or not to overwrite any existing output files | `TRUE` |
 
 
 |[View Genes of Interest Config File](../config/goi_config.yaml)|

--- a/optional-goi-analysis/goi-calculations.R
+++ b/optional-goi-analysis/goi-calculations.R
@@ -100,6 +100,12 @@ option_list <- list(
     default = NULL,
     help = "the path to the root directory for the R project and where the 
     `utils` folder lives."
+  ),
+  optparse::make_option(
+    c( "--overwrite"),
+    action = "store_true",
+    default = FALSE,
+    help = "specifies whether or not to overwrite existing output files"
   )
 )
 
@@ -133,9 +139,42 @@ if (!file.exists(opt$sce)){
   stop(paste(opt$sce, "does not exist."))
 }
 
-# Check that the outout directory exists
+# Check that the output directory exists
 if (!dir.exists(opt$output_directory)) {
   dir.create(opt$output_directory, recursive = TRUE)
+}
+
+# Define the output file paths
+output_mapped_genes <- file.path(
+  opt$output_directory,
+  paste0(opt$library_id, "_mapped_genes.tsv")
+)
+
+output_matrix <- file.path(
+  opt$output_directory,
+  paste0(opt$library_id, "_normalized_zscores.mtx")
+)
+
+output_annotation <- file.path(
+  opt$output_directory,
+  paste0(opt$library_id, "_heatmap_annotation.rds")
+)
+
+# Create a list of the expected output files
+output_files <- c(output_mapped_genes, output_matrix, output_annotation)
+
+# Check that any of the output files exist, only if the overwrite flag is false
+if (!opt$overwrite) {
+  if (any(file.exists(output_files))) {
+    existing_file <- output_files[file.exists(output_files)]
+    stop(
+      glue::glue(
+        "{existing_file} file exists, to overwrite please use the --overwrite flag
+        
+        "
+      )
+    )
+  }
 }
 
 #### Load libraries ------------------------------------------------------------
@@ -172,9 +211,10 @@ if(is.null(goi_list$gene_id)){
        Please rename the column holding your gene identifiers `gene_id` before 
        re-running this GOI analysis.")
 }
+
 #### Perform mapping -----------------------------------------------------------
 
-if (opt$perform_mapping == TRUE) {
+if (opt$perform_mapping) {
   # turn column name into symbol for pulling the column info out of data frame
   ids_for_mapping <- goi_list %>%
     dplyr::pull(gene_id)
@@ -241,10 +281,7 @@ if (opt$perform_mapping == TRUE) {
 }
 
 # Save goi list to file to be used as input for template 
-write_tsv(goi_list, file.path(
-  opt$output_directory,
-  paste0(opt$library_id, "_mapped_genes.tsv")
-))
+write_tsv(goi_list, output_mapped_genes)
 
 #### Prepare data for plotting -------------------------------------------------
 
@@ -297,17 +334,9 @@ if(!is.null(goi_list$gene_set)) {
 
 # Convert heatmap matrix to a sparse matrix and save to file
 normalized_zscores_matrix <- as(normalized_zscores_matrix, "sparseMatrix")
-Matrix::writeMM(normalized_zscores_matrix,
-          file.path(
-            opt$output_directory,
-            paste0(opt$library_id, "_normalized_zscores.mtx")
-          ))
+Matrix::writeMM(normalized_zscores_matrix, output_matrix)
 
 if(exists("column_annotation")) {
   # Save heatmap column annotation to file
-  write_rds(column_annotation,
-            file.path(
-              opt$output_directory,
-              paste0(opt$library_id, "_heatmap_annotation.rds")
-            ))
+  write_rds(column_annotation, output_annotation)
 }

--- a/optional-goi-analysis/goi-calculations.R
+++ b/optional-goi-analysis/goi-calculations.R
@@ -37,13 +37,13 @@ option_list <- list(
     c("-l", "--library_id"),
     type = "character",
     default = NULL,
-    help = "Unique ID corresponding to library being analyzed",
+    help = "unique ID corresponding to library being analyzed",
   ),
   optparse::make_option(
     c("-s", "--seed"),
     type = "integer",
     default = 2021,
-    help = "Random seed to set",
+    help = "random seed to set",
     metavar = "integer"
   ),
   optparse::make_option(
@@ -144,6 +144,12 @@ if (!dir.exists(opt$output_directory)) {
   dir.create(opt$output_directory, recursive = TRUE)
 }
 
+# Check that library id is not NULL
+if(is.null(opt$library_id)) {
+  stop("There is no library ID associated with the input data.
+       Please provide a library ID using the --library_id flag.")
+}
+
 # Define the output file paths
 output_mapped_genes <- file.path(
   opt$output_directory,
@@ -167,13 +173,8 @@ output_files <- c(output_mapped_genes, output_matrix, output_annotation)
 if (!opt$overwrite) {
   if (any(file.exists(output_files))) {
     existing_file <- output_files[file.exists(output_files)]
-    stop(
-      glue::glue(
-        "{existing_file} file exists, to overwrite please use the --overwrite flag
-        
-        "
-      )
-    )
+    print(glue::glue("{existing_file} file already exists."))
+    stop("To re-run analysis and overwrite all existing files please use the --overwrite flag.")
   }
 }
 


### PR DESCRIPTION
**Issue Addressed**
Closes #282

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR adds the `--overwrite` option to the `optional-goi-analysis/goi-calculations.R` script. This option allows us to account for all three expected output files -- if the `overwrite` option is not provided/is false, then there is a check to see if any of the three expected output files exist and a message to supply the `--overwrite` flag if any of them do exist.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR adds the `--overwrite` optparse option, defines the file paths of the expected output files at the beginning of the `goi-calculations.R` script, and adds a check to determine if any of the three output files already exist when `overwrite` is false/not provided.

This PR also updates the GOI config file and GOI `README` to reflect the added `overwrite` option.

**Any comments, concerns, or questions important for reviewers**
- Does this PR seem to appropriately address #282?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)