### PR TITLE
Fix typo in link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,4 +350,4 @@ For more on what's in the clustering analysis workflow and how to run the workfl
 There is an optional genes of interest analysis pipeline in the `optional-goi-analysis` subdirectory of this repository.
 This workflow can help users evaluate expression of a specific list of genes in their sample dataset and how the expression values compare to the remaining genes in the dataset.
 
-For more on what's in the genes of interest analysis workflow and how to run the workflow, see the [`README.md`](optional-goi-analysis/README.md#optional-clustering-analysis) file in the genes of interest analysis subdirectory.
+For more on what's in the genes of interest analysis workflow and how to run the workflow, see the [`README.md`](optional-goi-analysis/README.md) file in the genes of interest analysis subdirectory.


### PR DESCRIPTION
**Issue Addressed**
Another hot fix!

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Fixes a typo linking to the GOI docs from the main README.

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)