### PR TITLE
Sync core analysis results files to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ There are two expected output files thay will be associated with each provided `
     - Clustering that was performed within the workflow
 
 See the [expected output section](#expected-output) for more information on these output files.
-You can also download a ZIP file with examples of the summary HTML report and processed `SingleCellExperiment` objects stored as RDS files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/example_results.jpg).
+You can also download a ZIP file with an example of the output from running the core workflow, including the summary HTML report and processed `SingleCellExperiment` objects stored as RDS files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/core_example_results.zip).
 
 ## 1. How to install the core downstream analyses workflow
 
@@ -310,7 +310,7 @@ The `<library_id>_core_analysis_report.html` file is the [html file](https://boo
 
 The `<library_id>_processed_sce.rds` file is the [RDS file](https://rstudio-education.github.io/hopr/dataio.html#saving-r-files) that contains the final processed `SingleCellExperiment` object (which contains the filtered, normalized data and clustering results).
 
-You can also download a ZIP file with examples of the summary HTML report and processed `SingleCellExperiment` objects stored as RDS files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/example_results.jpg).
+You can also download a ZIP file with an example of the output from running the core workflow, including the summary HTML report and processed `SingleCellExperiment` objects stored as RDS files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/core_example_results.zip).
 
 ### What to expect in the output `SingleCellExperiment` object
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ There are two expected output files thay will be associated with each provided `
     - Clustering that was performed within the workflow
 
 See the [expected output section](#expected-output) for more information on these output files.
-You can also download an example of the summary HTML report [here](https://scpca-downstream-analyses.s3.amazonaws.com/example-results/sample01/library01_core_analysis_report.html) and an example of the processed `SingleCellExperiment` object as a RDS file [here](https://scpca-downstream-analyses.s3.amazonaws.com/example-results/sample01/library01_processed_sce.rds).
+You can also download a ZIP file with examples of the summary HTML report and processed `SingleCellExperiment` objects stored as RDS files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/example_results.jpg).
 
 ## 1. How to install the core downstream analyses workflow
 
@@ -310,7 +310,7 @@ The `<library_id>_core_analysis_report.html` file is the [html file](https://boo
 
 The `<library_id>_processed_sce.rds` file is the [RDS file](https://rstudio-education.github.io/hopr/dataio.html#saving-r-files) that contains the final processed `SingleCellExperiment` object (which contains the filtered, normalized data and clustering results).
 
-You can download an example of the summary HTML report [here](https://scpca-downstream-analyses.s3.amazonaws.com/example-results/sample01/library01_core_analysis_report.html) and an example of the processed `SingleCellExperiment` object as a RDS file [here](https://scpca-downstream-analyses.s3.amazonaws.com/example-results/sample01/library01_processed_sce.rds).
+You can also download a ZIP file with examples of the summary HTML report and processed `SingleCellExperiment` objects stored as RDS files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/example_results.jpg).
 
 ### What to expect in the output `SingleCellExperiment` object
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ There are two expected output files thay will be associated with each provided `
     - Clustering that was performed within the workflow
 
 See the [expected output section](#expected-output) for more information on these output files.
+You can also download an example of the summary HTML report [here](https://scpca-downstream-analyses.s3.amazonaws.com/example-results/sample01/library01_core_analysis_report.html) and an example of the processed `SingleCellExperiment` object as a RDS file [here](https://scpca-downstream-analyses.s3.amazonaws.com/example-results/sample01/library01_processed_sce.rds).
 
 ## 1. How to install the core downstream analyses workflow
 
@@ -308,6 +309,8 @@ example_results
 The `<library_id>_core_analysis_report.html` file is the [html file](https://bookdown.org/yihui/rmarkdown/html-document.html#html-document) that contains the summary report of the filtering, dimensionality reduction, and clustering results associated with the processed `SingleCellExperiment` object.
 
 The `<library_id>_processed_sce.rds` file is the [RDS file](https://rstudio-education.github.io/hopr/dataio.html#saving-r-files) that contains the final processed `SingleCellExperiment` object (which contains the filtered, normalized data and clustering results).
+
+You can download an example of the summary HTML report [here](https://scpca-downstream-analyses.s3.amazonaws.com/example-results/sample01/library01_core_analysis_report.html) and an example of the processed `SingleCellExperiment` object as a RDS file [here](https://scpca-downstream-analyses.s3.amazonaws.com/example-results/sample01/library01_processed_sce.rds).
 
 ### What to expect in the output `SingleCellExperiment` object
 

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -37,5 +37,5 @@ done
 
 # zip and sync example results
 zip -r core_example_results.zip $repo_base/example-results
-aws s3 cp core_example_results.zip $s3_base/example_results.jpg --acl public-read
+aws s3 cp core_example_results.zip $s3_base/core_example_results.zip --acl public-read
 rm ./core_example_results.zip

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -10,8 +10,8 @@ cd ..
 
 # location for the shared data
 share_base=/shared/data
-modules_base=${share_base}/scpca-downstream-analyses
-s3_base=s3://scpca-downstream-analyses
+repo_base=${share_base}/scpca-downstream-analyses
+s3_base=s3://scpca-references/example-data/scpca-downstream-analyses
 
 # create directory for example results
 mkdir -p example-results/sample01
@@ -35,4 +35,7 @@ do
   fi
 done
 
-aws s3 sync $modules_base $s3_base
+# zip and sync example results
+zip -r core_example_results.zip $repo_base/example-results
+aws s3 cp core_example_results.zip $s3_base/example_results.jpg --acl public-read
+rm ./core_example_results.zip

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -11,6 +11,7 @@ cd ..
 # location for the shared data
 share_base=/shared/data
 modules_base=${share_base}/scpca-downstream-analyses
+s3_base=s3://scpca-downstream-analyses
 
 # create directory for example results
 mkdir -p example-results/sample01
@@ -33,3 +34,5 @@ do
     echo "${loc} already exists and is not a link, delete or move it to create a link."
   fi
 done
+
+aws s3 sync $modules_base $s3_base


### PR DESCRIPTION
**Issue Addressed**
Closes #277 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR modifies the `utils/sync-results.sh` script to also sync the core analysis example results files from our shared directory to a S3 bucket named `scpca-downstream-analyses`.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
The `aws sync` command was added at the end of the script and the S3 bucket defined at the top of the script. I was able to successfully run this script to populate the S3 bucket that was created on AWS.

The main `README` is also updated in this PR to include links to the example results files in the S3 bucket.

**Any comments, concerns, or questions important for reviewers**
- Does the public S3 bucket seem to be properly created with the right permissions? For ease of reference: https://s3.console.aws.amazon.com/s3/buckets/scpca-downstream-analyses?region=us-east-1&tab=objects
- Do the links to the files work for you?
- Does this script seem to address all of issue #277?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)