### PR TITLE
Sync clustering analysis results files to S3

### DIFF
--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -63,6 +63,8 @@ For each provided `SingleCellExperiment` RDS file and associated `library_id`, t
 
 The TSV files will be saved in a subdirectory called `{library_id}_{filtering_method}_clustering_stats/`, where both the `{library_id}` and `{filtering_method}` are obtained from the input metadata file.
 
+You can also download a ZIP file with an example of the output from running the clustering workflow, including the summary HTML report, processed `SingleCellExperiment` objects stored as RDS files, and the clustering statistics saved as TSV files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/clustering_example_results.zip).
+
 ## Running the workflow
 
 As in the main core workflow, we have provided a [configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html), `config/config.yaml` which sets the defaults for project-specific parameters needed to run the clustering workflow.

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -20,19 +20,19 @@ mkdir -p clustering-example-results/sample01
 mkdir -p clustering-example-results/sample02
 
 link_locs=(
-  example-results/sample01/library01_processed_sce.rds
-  example-results/sample01/library01_core_analysis_report.html
-  example-results/sample02/library02_processed_sce.rds
-  example-results/sample02/library02_core_analysis_report.html
+  sample01/library01_processed_sce.rds
+  sample01/library01_core_analysis_report.html
+  sample02/library02_processed_sce.rds
+  sample02/library02_core_analysis_report.html
 )
 
 clustering_link_locs=(
-  clustering-example-results/sample01/library01_clustered_sce.rds
-  clustering-example-results/sample01/library01_clustering_report.html
-  clustering-example-results/sample01/library01_clustering_stats
-  clustering-example-results/sample02/library02_clustered_sce.rds
-  clustering-example-results/sample02/library02_clustering_report.html
-  clustering-example-results/sample02/library02_clustering_stats
+  sample01/library01_clustered_sce.rds
+  sample01/library01_clustering_report.html
+  sample01/library01_clustering_stats
+  sample02/library02_clustered_sce.rds
+  sample02/library02_clustering_report.html
+  sample02/library02_clustering_stats
 )
 
 for loc in ${link_locs[@]}
@@ -40,7 +40,7 @@ do
   # only make the links if replacing an old link or the file doesn't exist
   if [[ -L ${loc} || ! -e ${loc} ]]
   then
-    ln -nsf ${repo_base}/${loc} ${loc}
+    ln -nsf ${repo_base}/example-results/${loc} example-results/${loc}
   else
     echo "${loc} already exists and is not a link, delete or move it to create a link."
   fi
@@ -51,7 +51,7 @@ do
   # only make the links if replacing an old link or the file doesn't exist
   if [[ -L ${loc} || ! -e ${loc} ]]
   then
-    ln -nsf ${repo_base}/${loc} ${loc}
+    ln -nsf ${repo_base}/example-results/${loc} clustering-example-results/${loc}
   else
     echo "${loc} already exists and is not a link, delete or move it to create a link."
   fi

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -19,13 +19,15 @@ mkdir -p example-results/sample02
 mkdir -p clustering-example-results/sample01
 mkdir -p clustering-example-results/sample02
 
-link_locs=(
+# files only found in output from running core worfklow
+core_link_locs=(
   sample01/library01_processed_sce.rds
   sample01/library01_core_analysis_report.html
   sample02/library02_processed_sce.rds
   sample02/library02_core_analysis_report.html
 )
 
+# clustering module output files
 clustering_link_locs=(
   sample01/library01_clustered_sce.rds
   sample01/library01_clustering_report.html
@@ -35,7 +37,7 @@ clustering_link_locs=(
   sample02/library02_clustering_stats
 )
 
-for loc in ${link_locs[@]}
+for loc in ${core_link_locs[@]}
 do
   # only make the links if replacing an old link or the file doesn't exist
   if [[ -L ${loc} || ! -e ${loc} ]]
@@ -62,7 +64,7 @@ zip -r core_example_results.zip $repo_base/example-results
 aws s3 cp core_example_results.zip $s3_base/core_example_results.zip --acl public-read
 rm ./core_example_results.zip
 
-# zip and sync core analysis example results
+# zip and sync clustering module example results
 zip -r clustering_example_results.zip $repo_base/clustering-example-results
 aws s3 cp clustering_example_results.zip $s3_base/clustering_example_results.zip --acl public-read
 rm ./clustering_example_results.zip

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -16,6 +16,8 @@ s3_base=s3://scpca-references/example-data/scpca-downstream-analyses
 # create directory for example results
 mkdir -p example-results/sample01
 mkdir -p example-results/sample02
+mkdir -p clustering-example-results/sample01
+mkdir -p clustering-example-results/sample02
 
 link_locs=(
   example-results/sample01/library01_processed_sce.rds
@@ -24,18 +26,43 @@ link_locs=(
   example-results/sample02/library02_core_analysis_report.html
 )
 
+clustering_link_locs=(
+  clustering-example-results/sample01/library01_clustered_sce.rds
+  clustering-example-results/sample01/library01_clustering_report.html
+  clustering-example-results/sample01/library01_clustering_stats
+  clustering-example-results/sample02/library02_clustered_sce.rds
+  clustering-example-results/sample02/library02_clustering_report.html
+  clustering-example-results/sample02/library02_clustering_stats
+)
+
 for loc in ${link_locs[@]}
 do
   # only make the links if replacing an old link or the file doesn't exist
   if [[ -L ${loc} || ! -e ${loc} ]]
   then
-    ln -nsf ${modules_base}/${loc} ${loc}
+    ln -nsf ${repo_base}/${loc} ${loc}
   else
     echo "${loc} already exists and is not a link, delete or move it to create a link."
   fi
 done
 
-# zip and sync example results
+for loc in ${clustering_link_locs[@]}
+do
+  # only make the links if replacing an old link or the file doesn't exist
+  if [[ -L ${loc} || ! -e ${loc} ]]
+  then
+    ln -nsf ${repo_base}/${loc} ${loc}
+  else
+    echo "${loc} already exists and is not a link, delete or move it to create a link."
+  fi
+done
+
+# zip and sync core analysis example results
 zip -r core_example_results.zip $repo_base/example-results
 aws s3 cp core_example_results.zip $s3_base/core_example_results.zip --acl public-read
 rm ./core_example_results.zip
+
+# zip and sync core analysis example results
+zip -r clustering_example_results.zip $repo_base/clustering-example-results
+aws s3 cp clustering_example_results.zip $s3_base/clustering_example_results.zip --acl public-read
+rm ./clustering_example_results.zip


### PR DESCRIPTION
**Issue Addressed**
Closes #289 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
The purpose of this PR is to sync the clustering analysis results files to the shared data folder we have and to then zip and copy that folder to the scpca-references S3 bucket.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
In this PR, the `utils/sync-results.sh` script is modified to create a `clustering-example-results` subdirectory (parallel to the existing `example-results` subdirectory within the shared data directory), and to populate this new subdirectory with the clustering analysis output files.
Then just as we did in #292, the idea is that the clustering subdirectory would be zipped and copied to the S3 bucket.

This PR also updates the README in the optional-clustering-analysis directory to include the link to download the clustering_example_results.zip file from S3.

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->
I encountered a permissions issue upon attempting to create the `shared/data/scpca-downstream-analyses/clustering-example-results` subdirectory. See the error below:

`mkdir: cannot create directory ‘clustering-example-results’: Permission denied`

**Edit: The error has been solved 🎉 

**Any comments, concerns, or questions important for reviewers**
- Does this PR seem to adequately address #289?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)