### PR TITLE
Re-organize clustering module README and add section on colData contents

### DIFF
--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -19,7 +19,7 @@ This directory includes a clustering analysis workflow that can help users ident
 
 ## Analysis overview
 
-Libraries are unique, which means that the optimal clustering is likely to be library-dependent.
+Single-cell gene expression libraries are unique, which means that the optimal clustering is likely to be library-dependent.
 The clustering analysis workflow provided here can be used to explore different methods of clustering and test a range of parameter values for given graph-based clustering methods in order to identify the optimal clustering for each library.
 
 We evaluate the clustering results across each of the parameters tested by looking at the following measures:
@@ -45,7 +45,8 @@ If you are using conda, dependencies can be installed as [part of the initial se
 
 ## Running the workflow
 
-The execution file with the clustering Snakemake workflow is named cluster.snakefile and can be found in the root directory. To tell snakemake to run the specific clustering workflow be sure to use the --snakefile or -s option followed by the name of the snakefile, cluster.snakefile. After navigating to within the root directory of the scpca-downstream-analyses repository, the below example command can be used to run the clustering workflow:
+The execution file with the clustering Snakemake workflow is named `cluster.snakefile` and can be found in the root directory. To tell snakemake to run the specific clustering workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `cluster.snakefile`. 
+After navigating to within the root directory of the `scpca-downstream-analyses` repository, the below example command can be used to run the clustering workflow:
 
 ```
 snakemake --snakefile cluster.snakefile \ 
@@ -125,13 +126,24 @@ The parameters found in the `config/cluster_config.yaml` file can be optionally 
 
 For each provided `SingleCellExperiment` RDS file and associated `library_id`, the workflow will return five files in the same directory where the inputted RDS file is stored:
 
-1. The `SingleCellExperiment` RDS file containing the added clustering results that were calculated in the first step of the worflow.
+1. The `_clustered_sce.rds` file containing the `SingleCellExperiment` object with the added clustering results that were calculated in the first step of the workflow.
 2. The `_clustering_report.html` file, which is the summary html report with plots containing the clustering results.
 3. A `_clustering_all_validity_stats.tsv` file with all of the calculated cluster validity statistics.
 4. A `_clustering_summary_validity_stats.tsv` file with the cluster validity stats averaged across each cluster assignment.
 5. A `_clustering_summary_stability_stats.tsv` file with the average adjusted Rand Index (ARI) values across each cluster assignment.
 
-The TSV files will be saved in a subdirectory called `{library_id}_{filtering_method}_clustering_stats/`, where both the `{library_id}` and `{filtering_method}` are obtained from the input metadata file.
+Below is an example of the nested file structure you can expect.
+
+```
+example_results
+└── <sample_id>
+    ├── <library_id>_clustered_sce.rds
+    ├── <library_id>_clustering_report.html
+    ├── <library_id>_clustering_stats
+        ├── <library_id>_clustering_all_validity_stats.tsv
+        ├── <library_id>_clustering_summary_stability_stats.tsv
+        └── <library_id>_clustering_summary_validity_stats.tsv
+```
 
 You can also download a ZIP file with an example of the output from running the clustering workflow, including the summary HTML report, processed `SingleCellExperiment` objects stored as RDS files, and the clustering statistics saved as TSV files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/clustering_example_results.zip).
 

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -1,16 +1,6 @@
 # Optional Clustering Analysis
 
 This directory includes a clustering analysis workflow that can help users identify the optimal clustering method and parameters for each library in their dataset. 
-Libraries are unique, which means that the optimal clustering is likely to be library-dependent.
-The clustering analysis workflow provided here can be used to explore different methods of clustering and test a range of parameter values for given graph-based clustering methods in order to identify the optimal clustering for each library.
-
-We evaluate the clustering results across each of the parameters tested by looking at the following measures:
-
-1. **Cluster purity** - The cluster purity is calculated for each cell as the proportion of neighboring cells that are assigned to the same cluster, with a range of 0 to 1. Well-separated clusters should show little overlap between member and neighboring cells, and therefore high purity values for all member cells.
-2. **Silhouette width** - Silhouette width is calculated for each cell across clusters and measures how well-separated each of the clusters are, with a range of -1 to 1. For each cell, the average distance to all cells in the same cluster and the average distance to all cells in another cluster, are calculated. The silhouette width for each cell is defined as the difference between these two values divided by their maximum distance. Therefore, cells will ideally have large positive silhouette widths, as this would mean that the cells of one cluster are well-separated from other clusters.
-3. **Cluster stability** - The stability of the clustering results associated with each of the clustering parameters tested is also reported. Here, cells within each dataset are sampled using bootstrapping and the sampled cells are re-clustered. The new clustering assignments are compared to the original assignment by obtaining an adjusted rand index, and this process is repeated 20 times. Clustering results with high stability would reveal that clustering after each bootstrap replicate is consistent with the original clustering results. We use summary adjusted Rand Index (ARI) values in the plots shown in the clustering report output by the workflow to represent the average calculated cluster stability values. The range here is 0 to 1, where stable clusters have values closer to 1.
-
-For a more in depth discussion on these metrics and how they can be used to identify the optimal clustering results, see the [advanced clustering chapter in Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.15/OSCA.advanced/clustering-redux.html#motivation).
 
 **The clustering analysis workflow cannot be implemented until after users have successfully run the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file.**
 
@@ -29,6 +19,17 @@ For a more in depth discussion on these metrics and how they can be used to iden
 
 ## Analysis overview
 
+Libraries are unique, which means that the optimal clustering is likely to be library-dependent.
+The clustering analysis workflow provided here can be used to explore different methods of clustering and test a range of parameter values for given graph-based clustering methods in order to identify the optimal clustering for each library.
+
+We evaluate the clustering results across each of the parameters tested by looking at the following measures:
+
+1. **Cluster purity** - The cluster purity is calculated for each cell as the proportion of neighboring cells that are assigned to the same cluster, with a range of 0 to 1. Well-separated clusters should show little overlap between member and neighboring cells, and therefore high purity values for all member cells.
+2. **Silhouette width** - Silhouette width is calculated for each cell across clusters and measures how well-separated each of the clusters are, with a range of -1 to 1. For each cell, the average distance to all cells in the same cluster and the average distance to all cells in another cluster, are calculated. The silhouette width for each cell is defined as the difference between these two values divided by their maximum distance. Therefore, cells will ideally have large positive silhouette widths, as this would mean that the cells of one cluster are well-separated from other clusters.
+3. **Cluster stability** - The stability of the clustering results associated with each of the clustering parameters tested is also reported. Here, cells within each dataset are sampled using bootstrapping and the sampled cells are re-clustered. The new clustering assignments are compared to the original assignment by obtaining an adjusted rand index, and this process is repeated 20 times. Clustering results with high stability would reveal that clustering after each bootstrap replicate is consistent with the original clustering results. We use summary adjusted Rand Index (ARI) values in the plots shown in the clustering report output by the workflow to represent the average calculated cluster stability values. The range here is 0 to 1, where stable clusters have values closer to 1.
+
+For a more in depth discussion on these metrics and how they can be used to identify the optimal clustering results, see the [advanced clustering chapter in Orchestrating Single Cell Analysis](http://bioconductor.org/books/3.15/OSCA.advanced/clustering-redux.html#motivation).
+
 There are two main steps of this clustering analysis workflow:
 
 1. **Cluster Calculations**: Clustering results are calculated for the provided type(s) of graph-based clustering, and range of nearest neighbor values.
@@ -42,6 +43,24 @@ R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
 Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which must be installed locally prior to running the workflow.
 If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
 
+## Running the workflow
+
+The execution file with the clustering Snakemake workflow is named cluster.snakefile and can be found in the root directory. To tell snakemake to run the specific clustering workflow be sure to use the --snakefile or -s option followed by the name of the snakefile, cluster.snakefile. After navigating to within the root directory of the scpca-downstream-analyses repository, the below example command can be used to run the clustering workflow:
+
+```
+snakemake --snakefile cluster.snakefile \ 
+  --cores 2 \
+  --use-conda \
+  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>"
+```
+
+**You will want to replace the paths for both `results_dir` and `project_metadata` to successfully run the workflow.** 
+Where `results_dir` is the relative path to the directory where all results from running the workflow will be stored, and `project_metadata` is the relative path to the TSV file containing the relevant information about your input files.
+See more information on project metadata in the [expected input section](#expected-input) below.
+
+**Note:**  If you did not install dependencies [with conda via snakemake](../README.md#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
+
 ## Expected input
 
 To run this workflow, you will need to provide:
@@ -51,21 +70,7 @@ To run this workflow, you will need to provide:
 3. The desired type of graph-based clustering (can be "louvain" and/or "walktrap"), along with the minimum, maximum, and incremental values that will be used to define the range of nearest neighbor values to be tested.
 For example, if you would like a range of `5:25` to be tested in increments of 5 (as in, `5, 10, 15, 20, 25`), you will provide `nearest_neighbors_min` = 5, `nearest_neighbors_max` = 25, and `nearest_neighbors_increment` = 5.
 
-## Expected output
-
-For each provided `SingleCellExperiment` RDS file and associated `library_id`, the workflow will return five files in the same directory where the inputted RDS file is stored:
-
-1. The `SingleCellExperiment` RDS file containing the added clustering results that were calculated in the first step of the worflow.
-2. The `_clustering_report.html` file, which is the summary html report with plots containing the clustering results.
-3. A `_clustering_all_validity_stats.tsv` file with all of the calculated cluster validity statistics.
-4. A `_clustering_summary_validity_stats.tsv` file with the cluster validity stats averaged across each cluster assignment.
-5. A `_clustering_summary_stability_stats.tsv` file with the average adjusted Rand Index (ARI) values across each cluster assignment.
-
-The TSV files will be saved in a subdirectory called `{library_id}_{filtering_method}_clustering_stats/`, where both the `{library_id}` and `{filtering_method}` are obtained from the input metadata file.
-
-You can also download a ZIP file with an example of the output from running the clustering workflow, including the summary HTML report, processed `SingleCellExperiment` objects stored as RDS files, and the clustering statistics saved as TSV files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/clustering_example_results.zip).
-
-## Running the workflow
+## Parameters and config file
 
 As in the main core workflow, we have provided a [configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html), `config/config.yaml` which sets the defaults for project-specific parameters needed to run the clustering workflow.
 
@@ -88,23 +93,19 @@ You must also specify the number of CPU cores for snakemake to use by using the 
 If `--cores` is given without a number, all available cores are used to run the workflow.
 If you installed dependencies for the workflow [with conda via snakemake](../README.md#snakemakeconda-installation), you will need to provide the `--use_conda` flag as well.
 
-The execution file with the clustering Snakemake workflow is named `cluster.snakefile` and can be found in the root directory.
-To run tell snakemake to run the specific clustering workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `cluster.snakefile`.
-The below code is an example of running the clustering workflow using the project-specific parameters.
+The below code is an example of running the clustering workflow using the required parameters.
 
 ```
 snakemake --snakefile cluster.snakefile \ 
   --cores 2 \
   --use-conda \
-  --config results_dir="relative path to relevant results directory" \
-  project_metadata="relative path to your-project-metadata.TSV"
+  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>"
 ```
-
-**Note:**  If you did not install dependencies [with conda via snakemake](../README.md#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
 
 ### Clustering parameters
 
-We have provided an additional [configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html), `config/cluster_config.yaml` which sets the defaults for all parameters needed to run the clustering workflow.
+The [configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html), `config/cluster_config.yaml` sets the defaults for all parameters needed to run the clustering workflow.
 It is **not required** to alter these parameters to run the workflow, but if you would like to change the type of clustering or range of nearest neighbor parameters, you can do so by changing these parameters. 
 
 The parameters found in the `config/cluster_config.yaml` file can be optionally modified and are as follows:
@@ -119,3 +120,26 @@ The parameters found in the `config/cluster_config.yaml` file can be optionally 
 
 |[View Clustering Config File](../config/cluster_config.yaml)|
 |---|
+
+## Expected output
+
+For each provided `SingleCellExperiment` RDS file and associated `library_id`, the workflow will return five files in the same directory where the inputted RDS file is stored:
+
+1. The `SingleCellExperiment` RDS file containing the added clustering results that were calculated in the first step of the worflow.
+2. The `_clustering_report.html` file, which is the summary html report with plots containing the clustering results.
+3. A `_clustering_all_validity_stats.tsv` file with all of the calculated cluster validity statistics.
+4. A `_clustering_summary_validity_stats.tsv` file with the cluster validity stats averaged across each cluster assignment.
+5. A `_clustering_summary_stability_stats.tsv` file with the average adjusted Rand Index (ARI) values across each cluster assignment.
+
+The TSV files will be saved in a subdirectory called `{library_id}_{filtering_method}_clustering_stats/`, where both the `{library_id}` and `{filtering_method}` are obtained from the input metadata file.
+
+You can also download a ZIP file with an example of the output from running the clustering workflow, including the summary HTML report, processed `SingleCellExperiment` objects stored as RDS files, and the clustering statistics saved as TSV files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/clustering_example_results.zip).
+
+### What to expect in the output `SingleCellExperiment` object
+
+In the [`colData`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#handling-metadata) of the output `SingleCellExperiment` object, you can find the following:
+
+- Clustering results stored in a metadata column named using the associated clustering type and nearest neighbours values.
+For example, where `n` is a value within a range of nearest neighbors values provided to perform Louvain clustering, the column name would be `louvain_n` and can be accessed using `colData(sce)$louvain_n`.
+
+You can find more information on the above in the [processing information documentation](./additional-docs/processing-information.md).

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -124,7 +124,7 @@ The parameters found in the `config/cluster_config.yaml` file can be optionally 
 
 ## Expected output
 
-For each provided `SingleCellExperiment` RDS file and associated `library_id`, the workflow will return five files in the same directory where the inputted RDS file is stored:
+For each provided `SingleCellExperiment` RDS file and associated `library_id`, the workflow will return five files in the same directory where the input RDS file is stored:
 
 1. The `_clustered_sce.rds` file containing the `SingleCellExperiment` object with the added clustering results that were calculated in the first step of the workflow.
 2. The `_clustering_report.html` file, which is the summary html report with plots containing the clustering results.


### PR DESCRIPTION
**Issue Addressed**
Closes #294 and #240

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR re-organizes the clustering module README file per #294, to mirror that of the GOI module [README](https://github.com/AlexsLemonade/scpca-downstream-analyses/tree/main/optional-goi-analysis#readme).

This PR also adds a section under expected output mentioning the clustering results added to the colData of the object and how to access these results (per #240).

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
The `optional-clustering-analysis/README.md` file is re-organized here to follow the structure seen in the GOI docs which includes moving the table of contents up, then following that with the analysis overview, expected input, parameters and config file, and expected output sections.

"What to expect" in the output was also added in under the expected output section to outline what was added to the colData of the SingleCellExperiment objects (noting here that we did not add anything to the metadata of the SCEs in the clustering workflow).

**Any comments, concerns, or questions important for reviewers**
- Do these changes make sense to you? Do they seem to address both #294 and #240?

(For reference, this is stacked on PR #293 since some clustering docs changes were made there as well)

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)