### PR TITLE
Sync GOI example results files to S3

### DIFF
--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -171,3 +171,5 @@ For each provided `SingleCellExperiment` RDS file and associated `library_id`, t
 2. A `_normalized_zscores.mtx` matrix file with the z-scored matrix calculated using the normalized data specific to the provided genes of interest.
 3. A `_heatmap_annotation.rds` file with the annotations to be used when plotting the heatmap for the html report.
 4. The `_goi_report.html` file, which is the summary html report with plots containing the GOI results.
+
+You can download a ZIP file with an example of the output from running the genes of interest workflow, including the summary HTML report, the mapped genes TSV file, the z-scored matrix file, and the heatmap annotation RDS file [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/goi_example_results.zip).

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -172,4 +172,4 @@ For each provided `SingleCellExperiment` RDS file and associated `library_id`, t
 3. A `_heatmap_annotation.rds` file with the annotations to be used when plotting the heatmap for the html report.
 4. The `_goi_report.html` file, which is the summary html report with plots containing the GOI results.
 
-You can download a ZIP file with an example of the output from running the genes of interest workflow, including the summary HTML report, the mapped genes TSV file, the z-scored matrix file, and the heatmap annotation RDS file [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/goi_example_results.zip).
+You can download a ZIP file with an example of the output from running the genes of interest workflow, including the summary HTML report, the mapped genes TSV file, a `mtx` file containing z-scores, and the heatmap annotation RDS file [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/goi_example_results.zip).

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -37,6 +37,14 @@ clustering_link_locs=(
   sample02/library02_clustering_stats
 )
 
+# genes of interest module output files
+goi_link_locs=(
+  sample01/library01_goi_report.html
+  sample01/library01_goi_stats
+  sample02/library02_goi_report.html
+  sample02/library02_goi_stats
+)
+
 for loc in ${core_link_locs[@]}
 do
   # only make the links if replacing an old link or the file doesn't exist
@@ -59,6 +67,17 @@ do
   fi
 done
 
+for loc in ${goi_link_locs[@]}
+do
+  # only make the links if replacing an old link or the file doesn't exist
+  if [[ -L ${loc} || ! -e ${loc} ]]
+  then
+    ln -nsf ${repo_base}/example-results/${loc} goi-example-results/${loc}
+  else
+    echo "${loc} already exists and is not a link, delete or move it to create a link."
+  fi
+done
+
 # zip and sync core analysis example results
 zip -r core_example_results.zip $repo_base/example-results
 aws s3 cp core_example_results.zip $s3_base/core_example_results.zip --acl public-read
@@ -68,3 +87,8 @@ rm ./core_example_results.zip
 zip -r clustering_example_results.zip $repo_base/clustering-example-results
 aws s3 cp clustering_example_results.zip $s3_base/clustering_example_results.zip --acl public-read
 rm ./clustering_example_results.zip
+
+# zip and sync genes of interest module example results
+zip -r goi_example_results.zip $repo_base/goi-example-results
+aws s3 cp goi_example_results.zip $s3_base/goi_example_results.zip --acl public-read
+rm ./goi_example_results.zip


### PR DESCRIPTION
**Issue Addressed**
Closes #290 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
The purpose of this PR is to sync the genes of interest analysis results files to the shared data folder, zip the results up, and copy that folder to the scpca-references S3 bucket.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
Here, the `utils/sync-results.sh` script is modified to create a goi-example-results subdirectory and to populate this new subdirectory with the GOI analysis output files.
Then just as we did in https://github.com/AlexsLemonade/scpca-downstream-analyses/pull/293, the goi-example-results folder is zipped and copied to the S3 bucket.

The GOI module README in the optional-goi-analysis directory is also updated here to include the link to download the goi_example_results.zip file from S3.

See the link for reference: https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/goi_example_results.zip

**Any comments, concerns, or questions important for reviewers**
- Does the link work for you? 
- Does this seem to appropriately address #290?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)