### PR TITLE
Potential Conda/renv 

### DIFF
--- a/envs/scpca-renv.post-deploy.sh
+++ b/envs/scpca-renv.post-deploy.sh
@@ -3,8 +3,7 @@
 # install packages required for renv
 Rscript --vanilla -e \
   "
-   .libPaths(.Library)
-   install.packages(c('jsonlite', 'purrr'), repos = 'https://cloud.r-project.org')
+   library(glue)
    library(jsonlite)
    library(purrr)
    source('.Rprofile')

--- a/envs/scpca-renv.post-deploy.sh
+++ b/envs/scpca-renv.post-deploy.sh
@@ -7,6 +7,4 @@ Rscript --vanilla -e \
    library(jsonlite)
    source('.Rprofile')
    renv::restore()
-  " \
-  &> .snakemake/log/renv_install.log
-
+  " 

--- a/envs/scpca-renv.post-deploy.sh
+++ b/envs/scpca-renv.post-deploy.sh
@@ -3,9 +3,7 @@
 # install packages required for renv
 Rscript --vanilla -e \
   "
-   library(glue)
-   library(jsonlite)
-   library(purrr)
+   library(tidyverse)
    source('.Rprofile')
    renv::restore()
   "

--- a/envs/scpca-renv.post-deploy.sh
+++ b/envs/scpca-renv.post-deploy.sh
@@ -4,7 +4,9 @@
 Rscript --vanilla -e \
   "
    library(tidyverse)
+   library(jsonlite)
    source('.Rprofile')
    renv::restore()
-  "
+  " \
+  &> .snakemake/log/renv_install.log
 

--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -9,5 +9,5 @@ dependencies:
   - openssl
   - pandoc=2.19.2
   - pkg-config
-  - r-base=4.2.1
-  - r-tidyverse
+  - r-base=4.2.2
+  - r-tidyverse=2.0.0

--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -10,4 +10,5 @@ dependencies:
   - pandoc=2.19.2
   - pkg-config
   - r-base=4.2.2
+  - r-jsonlite=1.8.4
   - r-tidyverse=2.0.0

--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -10,3 +10,4 @@ dependencies:
   - pandoc=2.19.2
   - pkg-config
   - r-base=4.2.1
+  - r-tidyverse

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.2.1",
+    "Version": "4.2.2",
     "Repositories": [
       {
         "Name": "CRAN",

--- a/renv.lock
+++ b/renv.lock
@@ -5,6 +5,10 @@
       {
         "Name": "CRAN",
         "URL": "https://cloud.r-project.org"
+      },
+      {
+        "Name": "RSPM",
+        "URL": "https://packagemanager.rstudio.com/cran/latest"
       }
     ]
   },

--- a/renv/settings.dcf
+++ b/renv/settings.dcf
@@ -2,7 +2,7 @@ bioconductor.version: 3.16
 external.libraries:
 ignored.packages:
 package.dependency.fields: Imports, Depends, LinkingTo
-r.version: 4.2.1
+r.version: 4.2.2
 snapshot.type: implicit
 use.cache: TRUE
 vcs.ignore.cellar: TRUE

--- a/setup_envs.sh
+++ b/setup_envs.sh
@@ -7,5 +7,11 @@ set -euo pipefail
 # Run from the script file location
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
+# If on OSX with Apple Silicon, build the Intel version of R
+if [[ "$(uname)" == 'Darwin' && "$(uname -m)" == 'arm64' ]]; then
+  echo "On Apple Silicon: Building R environment and required R packages with CONDA_SUBDIR=osx-64 for compatibility"
+  CONDA_SUBDIR=osx-64 snakemake --use-conda --conda-create-envs-only -c1 -R build_renv
+fi
+
 echo "Building conda environments"
 snakemake --use-conda --conda-create-envs-only -c1


### PR DESCRIPTION
**Issue Addressed**

**What is the purpose of these changes?**

There were problems building the conda environment, which I ultimately tracked down to the fact that the latest version of `purrr` seems to now require `glue`. This only matters in the initial setup, but meant that other things didn't build as expected.  (Note that we were not pinning the `purrr` version here, because it was only used for installation, not in the actual running of code) In debugging I found that building the Apple Silicon versions of some packages (rhdf5) was also failing now, so I went back to using rosetta.


**What changes did you make?**

The main change is to load the whole tidyverse, rather than individual packages, when preparing to run the `renv::restore`. This is probably overkill, but it works. To enable this, I also install the `tidyverse` packages via `conda`, which allows me to pin the version, which hopefully will avoid a repeat of this problem in the future. 

Unfortunately, pinning the tidyverse version also seemed to require an updated to R 4.2.2, which seemed like it was probably an accepatable compromise

**Were there any other solutions that you tried?**

A potential alternative remains usign conda for all installs as described in #299, but I think that will take longer to implement, and may cause future headaches with keeping the `renv` in sync. 

**Any comments, concerns, or questions important for reviewers**

I'm filing this as a draft in part because I was not sure which branch I should target with these changes. Right now it is targeted at main, but let me know if another target is better! 

Also, others will need to pull these changes to test that things build as expected!

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)