### PR TITLE
Sync processed SCE object file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,12 +303,12 @@ Below is an example of the nested file structure you can expect.
 example_results
 └── sample_id
 	 ├── <library_id>_core_analysis_report.html
-	 └── <library_id>_processed_sce.rds
+	 └── <library_id>_processed.rds
 ```
 
 The `<library_id>_core_analysis_report.html` file is the [html file](https://bookdown.org/yihui/rmarkdown/html-document.html#html-document) that contains the summary report of the filtering, dimensionality reduction, and clustering results associated with the processed `SingleCellExperiment` object.
 
-The `<library_id>_processed_sce.rds` file is the [RDS file](https://rstudio-education.github.io/hopr/dataio.html#saving-r-files) that contains the final processed `SingleCellExperiment` object (which contains the filtered, normalized data and clustering results).
+The `<library_id>_processed.rds` file is the [RDS file](https://rstudio-education.github.io/hopr/dataio.html#saving-r-files) that contains the final processed `SingleCellExperiment` object (which contains the filtered, normalized data and clustering results).
 
 You can also download a ZIP file with an example of the output from running the core workflow, including the summary HTML report and processed `SingleCellExperiment` objects stored as RDS files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/core_example_results.zip).
 

--- a/Snakefile
+++ b/Snakefile
@@ -18,7 +18,7 @@ else:
 
 rule target:
     input:
-        expand(os.path.join(config["results_dir"], "{sample}/{library}_processed_sce.rds"),
+        expand(os.path.join(config["results_dir"], "{sample}/{library}_processed.rds"),
                zip,
                sample = SAMPLES,
                library = LIBRARY_ID),
@@ -106,7 +106,7 @@ rule clustering:
     input:
         "{basename}_dimreduced.rds"
     output:
-        "{basename}_processed_sce.rds"
+        "{basename}_processed.rds"
     log: "logs/{basename}/clustering.log"
     conda: "envs/scpca-renv.yaml"
     shell:
@@ -122,7 +122,7 @@ rule clustering:
 rule generate_report:
     input:
         pre_processed_sce = get_input_rds_files,
-        processed_sce =  "{basedir}/{sample_id}/{library_id}_processed_sce.rds"
+        processed_sce =  "{basedir}/{sample_id}/{library_id}_processed.rds"
     output:
         "{basedir}/{sample_id}/{library_id}_core_analysis_report.html"
     log: "logs/{basedir}/{sample_id}/{library_id}/generate_report.log"

--- a/cluster.snakefile
+++ b/cluster.snakefile
@@ -34,7 +34,7 @@ rule target:
 
 rule calculate_clustering:
     input:
-        "{basedir}/{library_id}_processed_sce.rds"
+        "{basedir}/{library_id}_processed.rds"
     output:
         sce = "{basedir}/{library_id}_clustered_sce.rds",
         stats_dir = directory("{basedir}/{library_id}_clustering_stats")

--- a/core-analysis/core-analysis-report-template.Rmd
+++ b/core-analysis/core-analysis-report-template.Rmd
@@ -2,7 +2,7 @@
 params:
   library: Library
   pre_processed_sce: "data/Gawad_processed_data/SCPCS000216/SCPCL000290_filtered.rds"
-  processed_sce: "results/Gawad_processed_data/SCPCS000216/SCPCL000290_miQC_processed_sce.rds"
+  processed_sce: "results/Gawad_processed_data/SCPCS000216/SCPCL000290_processed.rds"
   cluster_type: "louvain"
   nearest_neighbors: 10
   project_root: NULL

--- a/goi.snakefile
+++ b/goi.snakefile
@@ -30,7 +30,7 @@ rule target:
 
 rule calculate_goi:
     input:
-        "{basedir}/{library_id}_processed_sce.rds"
+        "{basedir}/{library_id}_processed.rds"
     output:
         output_dir = directory("{basedir}/{library_id}_goi_stats")
     log: "logs/{basedir}/{library_id}/calculate_goi.log"
@@ -52,7 +52,7 @@ rule calculate_goi:
         
 rule generate_goi_report:
     input:
-        processed_sce = "{basedir}/{library_id}_processed_sce.rds",
+        processed_sce = "{basedir}/{library_id}_processed.rds",
         goi_dir = "{basedir}/{library_id}_goi_stats"
     output:
         "{basedir}/{library_id}_goi_report.html"

--- a/optional-clustering-analysis/clustering-calculations.R
+++ b/optional-clustering-analysis/clustering-calculations.R
@@ -8,7 +8,7 @@
 # Command line usage:
 
 # Rscript --vanilla clustering-calculations.R \
-#   --sce "example-results/sample01/library01_miQC_processed_sce.rds" \
+#   --sce "example-results/sample01/library01_processed.rds" \
 #   --library_id "library01" \
 #   --seed 2021 \
 #   --cluster_types "louvain,walktrap" \

--- a/optional-goi-analysis/goi-calculations.R
+++ b/optional-goi-analysis/goi-calculations.R
@@ -6,7 +6,7 @@
 # Command line usage:
 
 # Rscript --vanilla goi-calculations.R \
-#   --sce "example-results/sample01/library01_miQC_processed_sce.rds" \
+#   --sce "example-results/sample01/library01_processed.rds" \
 #   --library_id "library01" \
 #   --seed 2021 \
 #   --input_goi_list "example-data/goi-lists/sample01_goi_list.tsv" \

--- a/optional-goi-analysis/goi-report-template.Rmd
+++ b/optional-goi-analysis/goi-report-template.Rmd
@@ -1,7 +1,7 @@
 ---
 params:
   library: "library01"
-  normalized_sce: "example-results/sample01/library01_processed_sce.rds"
+  normalized_sce: "example-results/sample01/library01_processed.rds"
   date: !r Sys.Date()
   goi_input_directory: "example-results/sample01/goi-stats"
   project_root: NULL

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -21,9 +21,9 @@ mkdir -p clustering-example-results/sample02
 
 # files only found in output from running core worfklow
 core_link_locs=(
-  sample01/library01_processed_sce.rds
+  sample01/library01_processed.rds
   sample01/library01_core_analysis_report.html
-  sample02/library02_processed_sce.rds
+  sample02/library02_processed.rds
   sample02/library02_core_analysis_report.html
 )
 


### PR DESCRIPTION
**Issue Addressed**
Closes #298

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
To begin syncing this repo to the other ScPCA products (scpca-nf and the portal), we are updating the file name for the processed SCE which would be the output of the core analysis workflow/the input of the module analyses to mirror that which would be downloaded from the ScPCA portal.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR removes `_sce` from any instance where this processed rds file is explicitly named, including in the following places:
- the core analysis `Snakefile`
- the module snakefiles
- the main README
- the `utils/sync-results.sh` script

I also re-ran things with these changes to ensure that they work as expected, and re-ran the `utils/sync-results.sh` script to update what's in the S3 bucket. 

**Any comments, concerns, or questions important for reviewers**
- Does it look like I covered all of the places that needed to be updated with this file name change?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)