### PR TITLE
Update miQC filtering - remove cells with low gene count

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -63,7 +63,7 @@ rule filter_data:
         "  --gene_detected_row_cutoff {config[gene_detected_row_cutoff]}"
         "  --gene_means_cutoff {config[gene_means_cutoff]}"
         "  --mito_percent_cutoff {config[mito_percent_cutoff]}"
-        "  --detected_gene_cutoff {config[detected_gene_cutoff]}"
+        "  --min_gene_cutoff {config[min_gene_cutoff]}"
         "  --umi_count_cutoff {config[umi_count_cutoff]}"
         "  --prob_compromised_cutoff {config[prob_compromised_cutoff]}"
         "  --filtering_method {config[filtering_method]}"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,7 +24,7 @@ prob_compromised_cutoff: 0.75 # Maximum miQC probability of cell being compromis
 gene_detected_row_cutoff: 5 # Percent of cells a gene must be detected in
 gene_means_cutoff: 0.1 # Mean gene expression minimum threshold
 mito_percent_cutoff: 20 # Maximum percent mitochondrial reads per cell threshold
-detected_gene_cutoff: 500 # Minimum number of genes detected per cell
+min_gene_cutoff: 200 # Minimum number of genes detected per cell
 umi_count_cutoff: 500 # Minimum UMI per cell
 
 # dimensionality reduction parameters

--- a/core-analysis/01-filter-sce.R
+++ b/core-analysis/01-filter-sce.R
@@ -83,10 +83,10 @@ option_list <- list(
     metavar = "double"
   ),
   optparse::make_option(
-    c("-p", "--detected_gene_cutoff"),
+    c("-p", "--min_gene_cutoff"),
     type = "integer",
-    default = 500,
-    help = "cell detected genes cutoff -- not needed for miQC filtering",
+    default = 200,
+    help = "cell detected genes cutoff",
     metavar = "integer"
   ),
   optparse::make_option(
@@ -196,6 +196,7 @@ if (opt$filtering_method == "manual") {
                                         mito_percent_cutoff = opt$mito_percent_cutoff,
                                         detected_gene_cutoff = opt$detected_gene_cutoff,
                                         umi_count_cutoff = opt$umi_count_cutoff)
+  metadata(filtered_sce)$scpca_filter_method <- "Minimum_gene_cutoff"
 
 
 } else if (opt$filtering_method == "miQC") {
@@ -217,12 +218,15 @@ if (opt$filtering_method == "manual") {
                           model = model,
                           posterior_cutoff = opt$prob_compromised_cutoff,
                           verbose = FALSE)
-
+      
+      # filter detected genes
+      filtered_sce <- filtered_sce[, colData(filtered_sce)$detected >= opt$min_gene_cutoff]
+      
       # Save model in metadata for plotting later
       metadata(filtered_sce)$miQC_model <- model
 
       # Include note in metadata re: filtering
-      metadata(filtered_sce)$filtering <- "miQC filtered"
+      metadata(filtered_sce)$scpca_filter_method <- "miQC"
       metadata(filtered_sce)$probability_compromised_cutoff <- opt$prob_compromised_cutoff
 
     }, silent = TRUE)
@@ -238,8 +242,9 @@ if (opt$filtering_method == "manual") {
     # manually filter the cells
     filtered_sce <- manual_cell_filtering(sce = sce_qc,
                                           mito_percent_cutoff = opt$mito_percent_cutoff,
-                                          detected_gene_cutoff = opt$detected_gene_cutoff,
+                                          detected_gene_cutoff = opt$min_gene_cutoff,
                                           umi_count_cutoff = opt$umi_count_cutoff)
+    metadata(filtered_sce)$scpca_filter_method <- "Minimum_gene_cutoff"
 
   }
 }
@@ -263,6 +268,7 @@ metadata(filtered_sce)$genes_filtered <- opt$filter_genes
 metadata(filtered_sce)$sample <- opt$sample_id
 metadata(filtered_sce)$library <- opt$library_id
 metadata(filtered_sce)$num_filtered_cells_retained <- dim(filtered_sce)[2]
+metadata(filtered_sce)$min_gene_cutoff <- opt$min_gene_cutoff
 
 # Save output filtered sce
 readr::write_rds(filtered_sce, output_file)

--- a/core-analysis/core-analysis-report-template.Rmd
+++ b/core-analysis/core-analysis-report-template.Rmd
@@ -97,12 +97,12 @@ sample_information <- tibble::tibble(
     format(num_cells_pre_processed, big.mark = ',', scientific = FALSE),
   "Cells after filtering" = 
     format(num_filtered_cells, big.mark = ',', scientific = FALSE),
-  "Filtering type" = 
-    format(processed_meta$filtering, big.mark = ',', scientific = FALSE)
+  "Filtering type" =
+    format(processed_meta$scpca_filter_method, big.mark = ',', scientific = FALSE)
 )
 
-if (processed_meta$filtering == "manually filtered"){
-  
+if (processed_meta$scpca_filter_method == "Minimum_gene_cutoff"){
+
   sample_information <- sample_information %>%
     mutate(
       "UMI count cutoff" = 
@@ -114,8 +114,8 @@ if (processed_meta$filtering == "manually filtered"){
     )
 }
 
-if (processed_meta$filtering == "miQC filtered" ){
-  
+if (processed_meta$scpca_filter_method == "miQC" ){
+
   sample_information <- sample_information %>%
     mutate("Probability compromised cutoff" = 
              format(processed_meta$probability_compromised_cutoff, big.mark = ',', scientific = FALSE))
@@ -147,7 +147,7 @@ The lines on the plot indicate the cutoffs, where cells with number of genes exp
 Additionally, cells are colored by percent mitochondrial reads. 
 Cells with percent mitochondrial reads above the provided cutoff are removed prior to downstream analysis.
 
-Here, cells were `r processed_meta$filtering`.
+Here, cells were filtered by `r processed_meta$scpca_filter_method`.
 
 
 ```{r}
@@ -162,7 +162,7 @@ if (is.null(pre_processed_sce$detected)) {
 
 
 ```{r}
-if (processed_meta$filtering == "manually filtered"){
+if (processed_meta$scpca_filter_method == "Minimum_gene_cutoff"){
   # Plot manual filtering thresholds
   filtered_cell_plot <- plot_manual_filtering(
     sce = pre_processed_sce,
@@ -170,7 +170,7 @@ if (processed_meta$filtering == "manually filtered"){
     umi_count_cutoff = processed_meta$umi_count_cutoff
   )
 }
-if (processed_meta$filtering == "miQC filtered" ){
+if (processed_meta$scpca_filter_method == "miQC" ){
   # Remove `prob_compromised` if it exists
   pre_processed_sce$prob_compromised <- NULL
   # Plot model

--- a/utils/filtering-functions.R
+++ b/utils/filtering-functions.R
@@ -30,7 +30,6 @@ manual_cell_filtering <- function(sce,
   # Include note in metadata re: filtering
   metadata(filtered_sce)$filtering <- "manually filtered"
   metadata(filtered_sce)$mito_percent_cutoff <- mito_percent_cutoff
-  metadata(filtered_sce)$detected_gene_cutoff <- detected_gene_cutoff
   metadata(filtered_sce)$umi_count_cutoff <- umi_count_cutoff
   
   return(filtered_sce)


### PR DESCRIPTION
**Issue Addressed**
Closes #308 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR adds a step to remove cells with low gene count when miQC filtering is implemented, to sync with what's done in `scpca-nf`.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR updates the miQC steps of the core workflow to also include filtering cells with low gene count using the `detected` column in the `colData`, as done in the scpca-nf workflow. This update was made in the `core-analysis/01-filter-sce.R` script.

As also noted on the issue, this PR changes `detected_gene_cutoff` to be `min_gene_cutoff`, changes the default to be 200 and stores it for both filtering methods.

This filtering method is also stored as `scpca_filter_method` now instead of `filtering`, with the two options being `Minimum_gene_cutoff` or `miQC`

**Any comments, concerns, or questions important for reviewers**
Does this PR seem to adequately address #308? Is anything missing?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)