### PR TITLE
Separate `results_dir` from input dir variable in clustering and GOI modules

### DIFF
--- a/cluster.snakefile
+++ b/cluster.snakefile
@@ -34,11 +34,11 @@ rule target:
 
 rule calculate_clustering:
     input:
-        "{basedir}/{library_id}_processed.rds"
+        os.path.join(config["input_data_dir"], "{sample_id}/{library_id}_processed.rds")
     output:
-        sce = "{basedir}/{library_id}_clustered_sce.rds",
-        stats_dir = directory("{basedir}/{library_id}_clustering_stats")
-    log: "logs/{basedir}/{library_id}/calculate_clustering.log"
+        sce = os.path.join(config["results_dir"], "{sample_id}/{library_id}_clustered_sce.rds"),
+        stats_dir = directory(os.path.join(config["results_dir"], "{sample_id}/{library_id}_clustering_stats"))
+    log: os.path.join("logs", config["results_dir"], "{sample_id}/{library_id}/calculate_clustering.log")
     conda: "envs/scpca-renv.yaml"
     shell:
         " Rscript --vanilla 'optional-clustering-analysis/clustering-calculations.R'"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,6 +4,7 @@
 # The below are parameters that are project-specific and should be customized to reflect the project or dataset being processed and the local setup.
 
 # file paths
+input_data_dir: "example-results"
 results_dir: "example-results"
 mito_file: "reference-files/Homo_sapiens.GRCh38.104.mitogenes.txt"
 project_metadata: "example-data/project-metadata/example-library-metadata.tsv"

--- a/goi.snakefile
+++ b/goi.snakefile
@@ -52,11 +52,11 @@ rule calculate_goi:
 
 rule generate_goi_report:
     input:
-        processed_sce = "{basedir}/{library_id}_processed.rds",
-        goi_dir = "{basedir}/{library_id}_goi_stats"
+        processed_sce = os.path.join(config["input_data_dir"], "{sample_id}/{library_id}_processed.rds"),
+        goi_dir = os.path.join(config["results_dir"], "{sample_id}/{library_id}_goi_stats")
     output:
-        "{basedir}/{library_id}_goi_report.html"
-    log: "logs/{basedir}/{library_id}/goi_report.log"
+        os.path.join(config["results_dir"], "{sample_id}/{library_id}_goi_report.html")
+    log: os.path.join("logs", config["results_dir"], "{sample_id}/{library_id}/goi_report.log")
     conda: "envs/scpca-renv.yaml"
     shell:
         """

--- a/goi.snakefile
+++ b/goi.snakefile
@@ -30,10 +30,10 @@ rule target:
 
 rule calculate_goi:
     input:
-        "{basedir}/{library_id}_processed.rds"
+        os.path.join(config["input_data_dir"], "{sample_id}/{library_id}_processed.rds")
     output:
-        output_dir = directory("{basedir}/{library_id}_goi_stats")
-    log: "logs/{basedir}/{library_id}/calculate_goi.log"
+        output_dir = directory(os.path.join(config["results_dir"], "{sample_id}/{library_id}_goi_stats"))
+    log: os.path.join("logs", config["results_dir"], "{sample_id}/{library_id}/calculate_goi.log")
     conda: "envs/scpca-renv.yaml"
     shell:
         " Rscript --vanilla 'optional-goi-analysis/goi-calculations.R'"

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -54,12 +54,13 @@ After navigating to within the root directory of the `scpca-downstream-analyses`
 snakemake --snakefile cluster.snakefile \ 
   --cores 2 \
   --use-conda \
-  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  --config input_data_dir="<RELATIVE PATH TO INPUT DATA DIRECTORY>" \
+  results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
   project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>"
 ```
 
-**You will want to replace the paths for both `results_dir` and `project_metadata` to successfully run the workflow.** 
-Where `results_dir` is the relative path to the directory where all results from running the workflow will be stored, and `project_metadata` is the relative path to the TSV file containing the relevant information about your input files.
+**You will want to replace the paths for `input_data_dir`, `results_dir` and `project_metadata` to successfully run the workflow.** 
+Where `input_data_dir` is the relative path to the directory where the input data files can be found, `results_dir` is the relative path to the directory where all results from running the workflow will be stored, and `project_metadata` is the relative path to the TSV file containing the relevant information about your input files.
 See more information on project metadata in the [expected input section](#expected-input) below.
 
 **Note:**  If you did not install dependencies [with conda via snakemake](../README.md#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
@@ -83,10 +84,11 @@ There are a set of parameters included in the `config/config.yaml` file that wil
 These parameters are specific to the project or dataset being processed.
 These include the following parameters:
 
-| Parameter        | Description |
-|------------------|-------------|
-| `results_dir` | relative path to the directory where output files will be stored (use the same `results_dir` used in the prerequisite core workflow) |
-| `project_metadata` | relative path to your specific project metadata TSV file (use the same `project_metadata` used in the prerequisite core workflow) |
+| Parameter        | Description | Default value |
+|------------------|-------------| --------------|
+| `input_data_dir` | relative path to the directory where the input data files can be found (default will be the `results_dir` used in the core workflow) | `"example_results"` |
+| `results_dir` | relative path to the directory where output files will be stored | `"example-results"` |
+| `project_metadata` | relative path to your specific project metadata TSV file (use the same `project_metadata` used in the prerequisite core workflow) | `"example-data/project-metadata/example-library-metadata.tsv"` |
 
 |[View Config File](../config/config.yaml)|
 |---|
@@ -102,7 +104,8 @@ The below code is an example of running the clustering workflow using the requir
 snakemake --snakefile cluster.snakefile \ 
   --cores 2 \
   --use-conda \
-  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  --config input_data_dir="<RELATIVE PATH TO INPUT DATA DIRECTORY>" \
+  results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
   project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>"
 ```
 

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -48,12 +48,13 @@ After navigating to within the root directory of the `scpca-downstream-analyses`
 snakemake --snakefile goi.snakefile \ 
   --cores 2 \
   --use-conda \
-  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  --config input_data_dir="<RELATIVE PATH TO INPUT DATA DIRECTORY>" \
+  results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
   project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>"
 ```
 
-**You will want to replace the paths for both `results_dir` and `project_metadata` to successfully run the workflow.** 
-Where `results_dir` is the relative path to the directory where all results from running the workflow will be stored, and `project_metadata` is the relative path to the TSV file containing the relevant information about your input files.
+**You will want to replace the paths for `input_data_dir`, `results_dir` and `project_metadata` to successfully run the workflow.** 
+Where `input_data_dir` is the relative path to the directory where the input data files can be found, `results_dir` is the relative path to the directory where all results from running the workflow will be stored, and `project_metadata` is the relative path to the TSV file containing the relevant information about your input files.
 See more information on project metadata in the [expected input section](#expected-input) below.
 
 **Note:**  If you did not install dependencies [with conda via snakemake](../README.md#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
@@ -81,7 +82,8 @@ These include the following parameters:
 
 | Parameter        | Description | Default value |
 |------------------|-------------| --------------|
-| `results_dir` | relative path to the directory where output files will be stored (use the same `results_dir` used in the prerequisite core workflow) | `"example-results"` |
+| `input_data_dir` | relative path to the directory where the input data files can be found (default will be the `results_dir` used in the core workflow) | `"example_results"` |
+| `results_dir` | relative path to the directory where output files will be stored | `"example-results"` |
 | `project_metadata` | relative path to your specific project metadata TSV file (use the same `project_metadata` used in the prerequisite core workflow) | `"example-data/project-metadata/example-library-metadata.tsv"` |
 | `goi_list` | the file path to a tsv file containing the list of genes that are of interest | `"example-data/goi-lists/example_goi_list.tsv"` |
 | `provided_identifier` | the type of gene identifiers used to populate the genes of interest list; example values that can implemented here include `"ENSEMBL"`, `"ENTREZID"`, `"SYMBOL"`; see more keytypes [here](https://jorainer.github.io/ensembldb/reference/EnsDb-AnnotationDbi.html) | `"SYMBOL"` |
@@ -98,7 +100,8 @@ The below code is an example of running the genes of interest workflow using the
 snakemake --snakefile goi.snakefile \ 
   --cores 2 \
   --use-conda \
-  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  --config input_data_dir="<RELATIVE PATH TO INPUT DATA DIRECTORY>" \
+  results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
   project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>" \
   goi_list="<RELATIVE PATH TO YOUR GENES OF INTEREST LIST>" \
   provided_identifier="<TYPE OF GENE IDENTIFIER USED IN GOI LIST>"
@@ -117,7 +120,8 @@ To run the workflow with the gene mapping step, you will only need to provide th
 snakemake --snakefile goi.snakefile \ 
   --cores 2 \
   --use-conda \
-  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  --config input_data_dir="<RELATIVE PATH TO INPUT DATA DIRECTORY>" \
+  results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
   project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>" \
   goi_list="<RELATIVE PATH TO YOUR GENES OF INTEREST LIST>" \
   provided_identifier="<TYPE OF GENE IDENTIFIER USED IN GOI LIST>"
@@ -129,7 +133,8 @@ To run the workflow without the gene mapping step, you can run the below command
 snakemake --snakefile goi.snakefile \ 
   --cores 2 \
   --use-conda \
-  --config results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
+  --config input_data_dir="<RELATIVE PATH TO INPUT DATA DIRECTORY>" \
+  results_dir="<RELATIVE PATH TO RESULTS DIRECTORY>" \
   project_metadata="<RELATIVE PATH TO YOUR PROJECT METADATA TSV>" \
   goi_list="<RELATIVE PATH TO YOUR GENES OF INTEREST LIST>" \
   provided_identifier="<TYPE OF GENE IDENTIFIER USED IN GOI LIST>" \


### PR DESCRIPTION
**Issue Addressed**
Closes #323

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR creates a separate `input_data_dir` variable for cases where users are using pre-processed data downloaded directly from the ScPCA portal. 

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
The clustering and GOI Snakefiles were both modified here to use an `input_data_dir` variable from the config file to specify the path to the `_processed.rds` object, and to use the `results_dir` variable to specify the paths to the output files.
The config file was also updated to include the `input_data_dir` with the default path being `example-results` which works in the case where users use the core analysis for generating the processed.rds object.

I also updated the README file in both modules here to reflect the addition of the `input_data_dir` variable.

**Any comments, concerns, or questions important for reviewers**
Does anything else need to be addressed in this PR to complete #323?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [x] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)