### PR TITLE
Add documentation on working with ScPCA portal data

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To run the core analysis workflow you will want to implement the following steps
 1. Clone the repository and install Snakemake using the [instructions provided in the Snakemake docs](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html#installation-via-conda-mamba).
 2. [Install the packages and dependencies](#c-additional-dependencies) that are required to run the workflow.
 3. Ensure that the input single-cell gene expression data are stored as `SingleCellExperiment` objects in RDS files (see more on this in the ["Input data format" section](#2-input-data-format)).
-The workflow can directly take as input the `filtered` RDS files downloaded from the [Single-cell Pediatric Cancer Atlas portal](https://scpca.alexslemonade.org/) or the output from the [scpca-nf workflow](https://github.com/AlexsLemonade/scpca-nf), a workflow that can be used to quantify your own single-cell/single-nuclei gene expression data.
+The workflow can directly take as input the `filtered` RDS files downloaded from the [Single-cell Pediatric Cancer Atlas portal](https://scpca.alexslemonade.org/) or the output from the [scpca-nf workflow](https://github.com/AlexsLemonade/scpca-nf), a workflow that can be used to quantify your own single-cell/single-nuclei gene expression data. If working with data from the ScPCA portal, see more information on preparing that data to run the core workflow [here](./additional-docs/working-with-scpca-portal-data.md).
 1. [Create a metadata tab-separated value (TSV) file](#3-metadata-file-format) that defines the sample id, library id, and filepath associated with the pre-processed `SingleCellExperiment` files to be used as input for the workflow.
 2. Open terminal to run the workflow using the following snakemake command and the `--config` flag to adjust the `results_dir` and `project_metadata` parameters to point to your desired results directory and project metadata file that you created in step 3:
 
@@ -171,6 +171,8 @@ The full path to each individual RDS file should be defined in the project metad
 The pipeline in this repository is setup to process data available on the [Single-cell Pediatric Cancer Atlas portal](https://scpca.alexslemonade.org/) and output from the [scpca-nf workflow](https://github.com/AlexsLemonade/scpca-nf) where single-cell/single-nuclei gene expression data is mapped and quantified using [alevin-fry](https://alevin-fry.readthedocs.io/en/latest/).
 For more information on the this pre-processing, please see the [ScPCA Portal docs](https://scpca.readthedocs.io/en/latest/).
 Note however that the input for this pipeline is **not required** to be scpca-nf processed output.
+
+If you are working with data downloaded from the ScPCA portal, see our guide on preparing that data to run the core workflow [here](./additional-docs/working-with-scpca-portal-data.md).
 
 ## 3. Metadata file format
 

--- a/additional-docs/working-with-scpca-portal-data.md
+++ b/additional-docs/working-with-scpca-portal-data.md
@@ -2,17 +2,18 @@
 
 Downloads from the ScPCA Portal include gene expression data, a QC report, and associated metadata for each processed sample.
 These files are delivered as a zip file.
-To find more information, visit the [ScPCA portal](https://scpca.alexslemonade.org/).
+To find more information on data available in the portal, visit the [ScPCA portal](https://scpca.alexslemonade.org/).
 
 ## Preparing the downloaded data for core workflow
 
-You can run the core downstream analysis workflow using the filtered RDS file and the metadata file found within the zip file downloaded from the ScPCA portal.
+The core downstream analysis workflow can take as input the `SingleCellExperiment` objects that are available in the filtered RDS files on the portal, files ending in `_filtered.rds`.
+You will also need information obtained in the metadata file found within the zip file downloaded from the ScPCA portal, `single_cell_metadata.tsv`.
 Before running the workflow, you will need to create a project metadata file as a tab-separated value (TSV) file that contains the relevant data for your input files needed to run the workflow.
 The metadata file should contain the following columns:
 
 - `sample_id`, the unique ID for each piece of tissue or sample that cells were obtained from, which can be found in the `scpca_sample_id` column of the downloaded `single_cell_metadata.tsv` file.
 - `library_id`, the unique ID used for each set of cells that has been prepped and sequenced separately, which can be found in the `scpca_library_id` columns of the downloaded `single_cell_metadata.tsv` file.
-- `filepath`, the full path to the `_filtered.rds` file containing the filtered `SingleCellExperiment` object.
+- `filepath`, the full path to the `_filtered.rds` file containing the filtered `SingleCellExperiment` object downloaded from the ScPCA portal.
 Each library ID should have a unique `filepath`.
 
 An example of the project metadata file would be as follows:
@@ -30,34 +31,43 @@ The below code is an example of running the Snakemake workflow using the project
 snakemake --cores 2 \
   --use-conda \
   --config results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
-  project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>" \
-  mito_file="<FULL PATH TO MITOCHONDRIAL GENES TXT FILE>"
+  project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"
 ```
 
 ## Preparing the downloaded data to run additional modules
 
-You can run the downstream analysis clustering and genes of interest workflows using the processed RDS file and the metadata file found within the zip file downloaded from the ScPCA portal.
+You can run any of the additional modules available (e.g., clustering or the genes of interest workflows) using the processed RDS file (ending in `_processed.rds`) and the metadata file (`single_cell_metadata.tsv`) found within the zip file downloaded from the ScPCA portal.
 Before running any of these workflows, you will need to create a project metadata file as a tab-separated value (TSV) file that contains the relevant data for your input files needed to run the workflow.
 The metadata file should contain the following columns:
 
 - `sample_id`, the unique ID for each piece of tissue or sample that cells were obtained from, which can be found in the `scpca_sample_id` column of the downloaded `single_cell_metadata.tsv` file.
 - `library_id`, the unique ID used for each set of cells that has been prepped and sequenced separately, which can be found in the `scpca_library_id` columns of the downloaded `single_cell_metadata.tsv` file.
-- `filepath`, the full path to the `_processed.rds` file containing the processed `SingleCellExperiment` object.
-Each library ID should have a unique `filepath`.
 
 An example of the project metadata file would be as follows:
 
-| sample_id | library_id | filepath |
-| --------- | ---------- | --------- |
-| SCPCS000122 | SCPCL000141 | example-data/SCPCS000122/SCPCL000141_processed.rds |
-| SCPCS000123	 | SCPCL000142 | example-data/SCPCS000123/SCPCL000142_processed.rds |
+| sample_id | library_id |
+| --------- | ---------- |
+| SCPCS000122 | SCPCL000141 |
+| SCPCS000123	 | SCPCL000142 |
+
+The required `input_data_dir` should also contain the downloaded input files as follows:
+
+```
+input_data_dir
+   ├── SCPCS000122
+   │   ├── SCPCL000141_processed.rds
+   │   └── single_cell_metadata.tsv
+   ├── SCPCS000123
+   │   ├── SCPCL000142_processed.rds
+   │   └── single_cell_metadata.tsv
+```
 
 ### Running the workflow
 
-The below code is an example of running the Snakemake clustering workflow using the project-specific parameters.
+The below code is an example of running the additional workflow(s) using the project-specific parameters, where `<module.snakefile>` would be replaced with the name of the snakefile associated with the desired module.
 
 ```
-snakemake --snakefile cluster.snakefile \ 
+snakemake --snakefile <module.snakefile> \ 
   --cores 2 \
   --use-conda \
   --config input_data_dir="<FULL PATH TO INPUT DATA DIRECTORY>" \
@@ -65,13 +75,6 @@ snakemake --snakefile cluster.snakefile \
   project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"
 ```
 
-The below code is an example of running the Snakemake genes of interest workflow using the project-specific parameters.
+To run the clustering workflow, see ["running the workflow"](../optional-clustering-analysis/README.md#running-the-workflow) in the clustering module `README.md`.
 
-```
-snakemake --snakefile goi.snakefile \ 
-  --cores 2 \
-  --use-conda \
-  --config input_data_dir="<FULL PATH TO INPUT DATA DIRECTORY>" \
-  results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
-  project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"
-```
+To run the genes of interest workflow, see ["running the workflow"](../optional-goi-analysis/README.md#running-the-workflow) in the genes of interest module `README.md`.

--- a/additional-docs/working-with-scpca-portal-data.md
+++ b/additional-docs/working-with-scpca-portal-data.md
@@ -2,6 +2,7 @@
 
 Downloads from the ScPCA Portal include gene expression data, a QC report, and associated metadata for each processed sample.
 These files are delivered as a zip file.
+Each sample's zip file should include a `SingleCellExperiment` object stored as `_filtered.rds` that can be used as input to the core analysis workflow, or to skip directly to the additional analysis modules, use the processed `SingleCellExperiment` object stored as `_processed.rds`.
 To find more information on data available in the portal, visit the [ScPCA portal](https://scpca.alexslemonade.org/).
 
 ## Preparing the downloaded data for core workflow
@@ -14,7 +15,8 @@ The metadata file should contain the following columns:
 - `sample_id`, the unique ID for each piece of tissue or sample that cells were obtained from, which can be found in the `scpca_sample_id` column of the downloaded `single_cell_metadata.tsv` file.
 - `library_id`, the unique ID used for each set of cells that has been prepped and sequenced separately, which can be found in the `scpca_library_id` columns of the downloaded `single_cell_metadata.tsv` file.
 - `filepath`, the full path to the `_filtered.rds` file containing the filtered `SingleCellExperiment` object downloaded from the ScPCA portal.
-Each library ID should have a unique `filepath`.
+Each library ID should have a unique `filepath` and will probably look something like this for each file: 
+`<full path to directory storing data downloaded from ScPCA/scpca_sample_id/scpca_library_id_filtered.rds`.
 
 An example of the project metadata file would be as follows:
 
@@ -50,7 +52,8 @@ An example of the project metadata file would be as follows:
 | SCPCS000122 | SCPCL000141 |
 | SCPCS000123	 | SCPCL000142 |
 
-The required `input_data_dir` should also contain the downloaded input files as follows:
+**Note:** Any of the additional modules will also need the parameter `input_data_dir` to be specified.
+The required `input_data_dir` should contain the downloaded input files as follows:
 
 ```
 input_data_dir

--- a/additional-docs/working-with-scpca-portal-data.md
+++ b/additional-docs/working-with-scpca-portal-data.md
@@ -1,7 +1,6 @@
 # Working with ScPCA portal data
 
 Downloads from the ScPCA Portal include gene expression data, a QC report, and associated metadata for each processed sample.
-These files are delivered as a zip file.
 Each sample's zip file should include a `SingleCellExperiment` object stored as `_filtered.rds` that can be used as input to the core analysis workflow, or to skip directly to the additional analysis modules, use the processed `SingleCellExperiment` object stored as `_processed.rds`.
 To find more information on data available in the portal, visit the [ScPCA portal](https://scpca.alexslemonade.org/).
 

--- a/additional-docs/working-with-scpca-portal-data.md
+++ b/additional-docs/working-with-scpca-portal-data.md
@@ -1,0 +1,77 @@
+# Working with ScPCA portal data
+
+Downloads from the ScPCA Portal include gene expression data, a QC report, and associated metadata for each processed sample.
+These files are delivered as a zip file.
+To find more information, visit the [ScPCA portal](https://scpca.alexslemonade.org/).
+
+## Preparing the downloaded data for core workflow
+
+You can run the core downstream analysis workflow using the filtered RDS file and the metadata file found within the zip file downloaded from the ScPCA portal.
+Before running the workflow, you will need to create a project metadata file as a tab-separated value (TSV) file that contains the relevant data for your input files needed to run the workflow.
+The metadata file should contain the following columns:
+
+- `sample_id`, the unique ID for each piece of tissue or sample that cells were obtained from, which can be found in the `scpca_sample_id` column of the downloaded `single_cell_metadata.tsv` file.
+- `library_id`, the unique ID used for each set of cells that has been prepped and sequenced separately, which can be found in the `scpca_library_id` columns of the downloaded `single_cell_metadata.tsv` file.
+- `filepath`, the full path to the `_filtered.rds` file containing the filtered `SingleCellExperiment` object.
+Each library ID should have a unique `filepath`.
+
+An example of the project metadata file would be as follows:
+
+| sample_id | library_id | filepath |
+| --------- | ---------- | --------- |
+| SCPCS000122 | SCPCL000141 | example-data/SCPCS000122/SCPCL000141_filtered.rds |
+| SCPCS000123	 | SCPCL000142 | example-data/SCPCS000123/SCPCL000142_filtered.rds |
+
+### Running the workflow
+
+The below code is an example of running the Snakemake workflow using the project-specific parameters.
+
+```
+snakemake --cores 2 \
+  --use-conda \
+  --config results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
+  project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>" \
+  mito_file="<FULL PATH TO MITOCHONDRIAL GENES TXT FILE>"
+```
+
+## Preparing the downloaded data to run additional modules
+
+You can run the downstream analysis clustering and genes of interest workflows using the processed RDS file and the metadata file found within the zip file downloaded from the ScPCA portal.
+Before running any of these workflows, you will need to create a project metadata file as a tab-separated value (TSV) file that contains the relevant data for your input files needed to run the workflow.
+The metadata file should contain the following columns:
+
+- `sample_id`, the unique ID for each piece of tissue or sample that cells were obtained from, which can be found in the `scpca_sample_id` column of the downloaded `single_cell_metadata.tsv` file.
+- `library_id`, the unique ID used for each set of cells that has been prepped and sequenced separately, which can be found in the `scpca_library_id` columns of the downloaded `single_cell_metadata.tsv` file.
+- `filepath`, the full path to the `_processed.rds` file containing the processed `SingleCellExperiment` object.
+Each library ID should have a unique `filepath`.
+
+An example of the project metadata file would be as follows:
+
+| sample_id | library_id | filepath |
+| --------- | ---------- | --------- |
+| SCPCS000122 | SCPCL000141 | example-data/SCPCS000122/SCPCL000141_processed.rds |
+| SCPCS000123	 | SCPCL000142 | example-data/SCPCS000123/SCPCL000142_processed.rds |
+
+### Running the workflow
+
+The below code is an example of running the Snakemake clustering workflow using the project-specific parameters.
+
+```
+snakemake --snakefile cluster.snakefile \ 
+  --cores 2 \
+  --use-conda \
+  --config input_data_dir="<FULL PATH TO INPUT DATA DIRECTORY>" \
+  results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
+  project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"
+```
+
+The below code is an example of running the Snakemake genes of interest workflow using the project-specific parameters.
+
+```
+snakemake --snakefile goi.snakefile \ 
+  --cores 2 \
+  --use-conda \
+  --config input_data_dir="<FULL PATH TO INPUT DATA DIRECTORY>" \
+  results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
+  project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"
+```

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -2,7 +2,7 @@
 
 This directory includes a clustering analysis workflow that can help users identify the optimal clustering method and parameters for each library in their dataset. 
 
-**The clustering analysis workflow cannot be implemented until after users have successfully run the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file.**
+**The clustering analysis workflow cannot be implemented until after users have successfully run the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file or have downloaded data from the [ScPCA portal](https://scpca.alexslemonade.org/).**
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -69,10 +69,12 @@ See more information on project metadata in the [expected input section](#expect
 
 To run this workflow, you will need to provide:
 
-1. The RDS file containing the [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow.
-2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, the same metadata file used in the core workflow should be used here (see more on this in the ["Metadata file format" section](../README.md#metadata-file-format) and an example of this metadata file [here](../project-metadata/example-library-metadata.tsv)).
+1. The RDS file containing the [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow or data downloaded from the ScPCA portal.
+2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, the same metadata file used in the core workflow can be used here (see more on this in the ["Metadata file format" section](../README.md#metadata-file-format) and an example of this metadata file [here](../project-metadata/example-library-metadata.tsv)).
 3. The desired type of graph-based clustering (can be "louvain" and/or "walktrap"), along with the minimum, maximum, and incremental values that will be used to define the range of nearest neighbor values to be tested.
 For example, if you would like a range of `5:25` to be tested in increments of 5 (as in, `5, 10, 15, 20, 25`), you will provide `nearest_neighbors_min` = 5, `nearest_neighbors_max` = 25, and `nearest_neighbors_increment` = 5.
+
+If you are working with data from the ScPCA portal, see our guide on preparing that data to run the clustering workflow [here](../additional-docs/working-with-scpca-portal-data.md).
 
 ## Parameters and config file
 

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -69,8 +69,8 @@ See more information on project metadata in the [expected input section](#expect
 
 To run this workflow, you will need to provide:
 
-1. The RDS file containing the [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow or data downloaded from the ScPCA portal.
-2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, the same metadata file used in the core workflow can be used here (see more on this in the ["Metadata file format" section](../README.md#metadata-file-format) and an example of this metadata file [here](../project-metadata/example-library-metadata.tsv)).
+1. The RDS file containing the [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow or a processed `SingleCellExperiment` object downloaded from the ScPCA portal (found in the `_processed.rds` file).
+2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, the same metadata file used in the core workflow can be used here -- although only the `sample_id` and `library_id` columns are required for this workflow (see more on this in the ["Metadata file format" section](../README.md#metadata-file-format) and an example of this metadata file [here](../project-metadata/example-library-metadata.tsv)).
 3. The desired type of graph-based clustering (can be "louvain" and/or "walktrap"), along with the minimum, maximum, and incremental values that will be used to define the range of nearest neighbor values to be tested.
 For example, if you would like a range of `5:25` to be tested in increments of 5 (as in, `5, 10, 15, 20, 25`), you will provide `nearest_neighbors_min` = 5, `nearest_neighbors_max` = 25, and `nearest_neighbors_increment` = 5.
 

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -3,7 +3,7 @@
 This directory includes a genes of interest analysis workflow to help users evaluate expression of a specific list of genes in a sample dataset.
 
 
-**The genes of interest (GOI) analysis workflow cannot be implemented until after users have successfully run the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file.**
+**The genes of interest (GOI) analysis workflow cannot be implemented until after users have successfully run the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file or have downloaded data from the [ScPCA portal](https://scpca.alexslemonade.org/).**
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -64,11 +64,13 @@ See more information on project metadata in the [expected input section](#expect
 
 To run this workflow, you will need to provide:
 
-1. The RDS file containing the normalized [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow.
+1. The RDS file containing the normalized [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow or the processed object downloaded from the ScPCA portal.
 This `SingleCellExperiment` object must contain a log-normalized counts matrix in an assay named `logcounts`.
-2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, the same metadata file used in the core workflow should be used here (see more on this in the ["Metadata file format" section](../README.md#metadata-file-format) and an example of this metadata file [here](../project-metadata/example-library-metadata.tsv)).
+2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, the same metadata file used in the core workflow can be used here (see more on this in the ["Metadata file format" section](../README.md#metadata-file-format) and an example of this metadata file [here](../project-metadata/example-library-metadata.tsv)).
 3. The genes of interest list, stored as a tab-separated value (TSV) file.
 This file should contain at least one column named `gene_id` with the relevant gene identifiers, and can optionally contain an additional column named `gene_set` that denotes the gene set that each gene identifier belongs to (see an example of this genes of interest file [here](../example-data/goi-lists/sample01_goi_list.tsv)).
+
+If working with data from the ScPCA portal, see our guide on preparing that data to run the genes of interest workflow [here](./additional-docs/working-with-scpca-portal-data.md).
 
 ## Parameters and config file
 

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -64,9 +64,9 @@ See more information on project metadata in the [expected input section](#expect
 
 To run this workflow, you will need to provide:
 
-1. The RDS file containing the normalized [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow or the processed object downloaded from the ScPCA portal.
+1. The RDS file containing the normalized [output `SingleCellExperiment` object](../README.md#expected-output) from the core dowstream analyses workflow or the processed `SingleCellExperiment` object downloaded from the ScPCA portal (found in the `_processed.rds` file).
 This `SingleCellExperiment` object must contain a log-normalized counts matrix in an assay named `logcounts`.
-2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, the same metadata file used in the core workflow can be used here (see more on this in the ["Metadata file format" section](../README.md#metadata-file-format) and an example of this metadata file [here](../project-metadata/example-library-metadata.tsv)).
+2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, the same metadata file used in the core workflow can be used here -- although only the `sample_id` and `library_id` columns are required for this workflow (see more on this in the ["Metadata file format" section](../README.md#metadata-file-format) and an example of this metadata file [here](../project-metadata/example-library-metadata.tsv)).
 3. The genes of interest list, stored as a tab-separated value (TSV) file.
 This file should contain at least one column named `gene_id` with the relevant gene identifiers, and can optionally contain an additional column named `gene_set` that denotes the gene set that each gene identifier belongs to (see an example of this genes of interest file [here](../example-data/goi-lists/sample01_goi_list.tsv)).
 


### PR DESCRIPTION
**Issue Addressed**
Closes #313 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
Now that we have synced the workflows in this repo with what's on the ScPCA portal, it's a great time to incorporate documentation in this repo on using data downloaded from the portal with these workflows.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
This PR adds `additional-docs/working-with-scpca-portal-data.md` to guide users on how to prepare their project metadata file when using data downloaded from the ScPCA portal.
The main README and module README files are also updated here to link to the working-with-scpca-portal-data.md documentation.

**Any comments, concerns, or questions important for reviewers**
- Does this added documentation seem clear and easy to follow to you?
- Can you think of any additional details that may be beneficial if added to the documentation in this PR?

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)