### PR TITLE
Add dimensionality reduction results to merged SCE 

### DIFF
--- a/optional-integration-analysis/merge-sce.R
+++ b/optional-integration-analysis/merge-sce.R
@@ -105,5 +105,37 @@ merged_sce <- scpcaTools::merge_sce_list(sce_list,
                                          preserve_rowdata_cols = "gene_symbol",
                                          cell_id_column = "cell_id")
 
+# HVG selection ----------------------------------------------------------------
+
+# Extract the batch column
+batch_column <- merged_sce$library_id
+
+# Model gene variance
+gene_var_block <- scran::modelGeneVar(merged_sce,
+                                      block = batch_column,
+                                      BPPARAM = bp_param)
+# Identify subset of variable genes
+hvg_list <- scran::getTopHVGs(gene_var_block,
+                              n = opt$n_hvg)
+
+metadata(merged_sce)$merged_hvgs <- hvg_list
+
+# Dim Reduction PCA and UMAP----------------------------------------------------
+
+# Multi batch PCA on merged object
+multi_pca <- batchelor::multiBatchPCA(merged_sce,
+                                      subset.row = hvg_list,
+                                      batch = batch_column,
+                                      preserve.single = TRUE,
+                                      BPPARAM = bp_param)
+
+# Add PCA results
+reducedDim(merged_sce, "PCA") <- multi_pca[[1]]
+
+# Add UMAP results
+merged_sce <- scater::runUMAP(merged_sce,
+                              dimred = "PCA",
+                              BPPARAM = bp_param)
+
 # Save combined SCE object
 readr::write_rds(merged_sce, opt$output_sce_file)


### PR DESCRIPTION
**Issue Addressed**
Closes #333

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR adds steps to the `merge-sce.R` script in the data integration module to calculate and add PCA and UMAP results to the merged SCE object. 

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->

Per issue #332, the following steps were added to the `merge-sce.R` script:

- identify the subset of highly variable genes
- perform multi-batch PCA
- perform UMAP

**Any comments, concerns, or questions important for reviewers**

I was torn on whether or not we want to include the `integration_group` metadata column in this PR and begin to account for that variable in this script, but decided not to in order to keep this PR a bit simpler to review. 

Let me know if you think we should begin to account for  `integration_group` here however!

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)