### PR TITLE
Allow for merging of SCEs by integration group

### DIFF
--- a/example-data/project-metadata/example-integration-library-metadata.tsv
+++ b/example-data/project-metadata/example-integration-library-metadata.tsv
@@ -1,5 +1,3 @@
 sample_id	library_id	processed_sce_filepath	integration_group
 sample01	library01	example-results/sample01/library01_processed.rds	group01
 sample02	library02	example-results/sample02/library02_processed.rds	group01
-SCPCS000122	SCPCL000141	example-results/SCPCS000122/SCPCL000141_processed.rds	group02
-SCPCS000123	SCPCL000142	example-results/SCPCL000142/SCPCL000142_processed.rds	group02

--- a/example-data/project-metadata/example-integration-library-metadata.tsv
+++ b/example-data/project-metadata/example-integration-library-metadata.tsv
@@ -1,3 +1,5 @@
-sample_id	library_id	processed_sce_filepath
-sample01	library01	example-results/sample01/library01_processed.rds
-sample02	library02	example-results/sample02/library02_processed.rds
+sample_id	library_id	processed_sce_filepath	integration_group
+sample01	library01	example-results/sample01/library01_processed.rds	group01
+sample02	library02	example-results/sample02/library02_processed.rds	group01
+SCPCS000122	SCPCL000141	example-results/SCPCS000122/SCPCL000141_processed.rds	group02
+SCPCS000123	SCPCL000142	example-results/SCPCL000142/SCPCL000142_processed.rds	group02

--- a/optional-integration-analysis/merge-sce.R
+++ b/optional-integration-analysis/merge-sce.R
@@ -15,11 +15,16 @@ option_list <- list(
     help = "Path to the TSV file containing the list of library IDs corresponding to the libraries being integrated, must have `library_id` and `processed_sce_filepath` columns."
   ),
   make_option(
+    opt_str = c("--integration_group"),
+    type = "character",
+    help = "The integration group associated with the SCEs to be merged"
+  ),
+  make_option(
     opt_str = c("-o", "--output_sce_file"),
     type = "character",
     help = "Path to output RDS file containing merged object, must end in .rds"
   ),
-  optparse::make_option(
+  make_option(
     c("--project_root"),
     type = "character",
     default = NULL,
@@ -70,6 +75,15 @@ if(is.null(opt$input_metadata_tsv)){
 } else {
   # List of library ids
   input_metadata <- readr::read_tsv(opt$input_metadata_tsv)
+}
+
+# Check that integration group is provided
+if(is.null(opt$integration_group)){
+  stop("The name of the corresponding integration group is missing.")
+} else {
+  # Filter the metadata to include only information relevant to the specified integration group
+  input_metadata <- input_metadata %>%
+    dplyr::filter(integration_group == opt$integration_group)
 }
 
 # List of SCE filepaths

--- a/optional-integration-analysis/merge-sce.R
+++ b/optional-integration-analysis/merge-sce.R
@@ -78,8 +78,10 @@ if(is.null(opt$input_metadata_tsv)){
 }
 
 # Check that integration group is provided
-if(is.null(opt$integration_group)){
-  stop("The name of the corresponding integration group is missing.")
+if(is.null(opt$integration_group)) {
+  stop("The `integration_group` is missing and required for identifying which objects should be merged together.")
+} else if (!opt$integration_group %in% input_metadata$integration_group) {
+  stop("The provided `integration_group` is missing from the input metadata file.")
 } else {
   # Filter the metadata to include only information relevant to the specified integration group
   input_metadata <- input_metadata %>%


### PR DESCRIPTION
**Issue Addressed**
Closes #340

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
The purpose of this PR is to allow users to specify which integration group each SCE belongs to (e.g. libraries from the same disease are merged together rather than all libraries being merged together into one).

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
The following modifications were made to the `merge-sce.R` script in the data integration module:
- an argument to take the desired `integration_group`
- a step to filter in the input metadata on that integration group argument

These modifications allow users to indicate which libraries (SCEs) should be grouped together.

The example metadata file was also updated to included an `integration_group` column and filled in with generic values.

**Any comments, concerns, or questions important for reviewers**
Does this PR see to adequately address #340?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)