### PR TITLE
Add script to perform integration

### DIFF
--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -12,16 +12,16 @@ library(scpcaTools)
 # Declare command line options
 option_list <- list(
   make_option(
-    opt_str = c("--merged_sce_rds"),
+    opt_str = c("--merged_sce_file"),
     type = "character",
     help = "Path to the RDS file containing the merged SCE object"
   ),
   make_option(
     opt_str = c("--integration_method"),
     type = "character",
-    default = c("fastMNN", "harmony"),
+    default = "fastMNN, harmony",
     help = "The integration method(s) to use when performing integration; 
-    default is c('fastMNN', 'harmony')"
+    default is 'fastMNN, harmony'"
   ),
   make_option(
     opt_str = c("-o", "--output_sce_file"),
@@ -60,26 +60,50 @@ if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
   stop("output file name must end in .rds")
 }
 
+# Check that merged SCE file exists
+if(!file.exists(opt$merged_sce_file)){
+  stop(paste(opt$merged_sce_file, "does not exist."))
+}
+
 # Read in merged SCE -----------------------------------------------------------
 
-merged_sce <- readr::read_rds(opt$merged_sce_rds)
+merged_sce <- readr::read_rds(opt$merged_sce_file)
 
 # Integrate SCEs ---------------------------------------------------------------
 
+# Split up string of integration methods
+integration_methods <-  stringr::str_split(opt$integration_method, ",") %>%
+  unlist() %>%
+  stringr::str_trim()
+
+# Check that we support the provided integration method(s)
+for (integration_method in integration_methods) {
+  if (!integration_method %in% c("fastMNN", "harmony")) {
+    stop("--integration_method must be either fastMNN, harmony, or both (comma-separated)")
+  }
+}
+
+# Check that `library_id` is in merged SCE object
+if(!("library_id" %in% colnames(colData(merged_sce)))){
+  stop("The 'library_id' column is missing from the `colData` of the merged SCE 
+       object and is needed for integration.")
+}
+
 # Perform integration with specified method
-if ("fastMNN" %in% opt$integration_method) {
+if ("fastMNN" %in% integration_methods) {
   integrated_sce <- integrate_sces(merged_sce,
                                    integration_method = "fastMNN",
                                    batch_column = "library_id")
+  scater::runUMAP(integrated_sce, dimred = "fastMNN_PCA", name = "fastMNN_UMAP")
 }
 
-if ("harmony" %in% opt$integration_method) {
+if ("harmony" %in% integration_methods) {
   integrated_sce <- integrate_sces(merged_sce,
                                    integration_method = "harmony",
                                    batch_column = "library_id")
+  scater::runUMAP(integrated_sce, dimred = "harmony_PCA", name = "harmony_UMAP")
 }
 
 # Write integrated object to file ----------------------------------------------
 
-write_rds(integrated_sce, opt$output_sce_file)
-
+readr::write_rds(integrated_sce, opt$output_sce_file)

--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -1,0 +1,85 @@
+## This script performs integration on processed SCE objects that have been
+## merged in the `merge-sce.R` script
+
+## Set up ----------------------------------------------------------------------
+
+# Load libraries
+library(optparse)
+library(dplyr)
+library(SingleCellExperiment)
+library(scpcaTools)
+
+# Declare command line options
+option_list <- list(
+  make_option(
+    opt_str = c("--merged_sce_rds"),
+    type = "character",
+    help = "Path to the RDS file containing the merged SCE object"
+  ),
+  make_option(
+    opt_str = c("--integration_method"),
+    type = "character",
+    default = c("fastMNN", "harmony"),
+    help = "The integration method(s) to use when performing integration; 
+    default is c('fastMNN', 'harmony')"
+  ),
+  make_option(
+    opt_str = c("-o", "--output_sce_file"),
+    type = "character",
+    help = "Path to output RDS file containing integrated object, must end in .rds"
+  ),
+  make_option(
+    c("--project_root"),
+    type = "character",
+    default = NULL,
+    help = "Path to the root directory for the R project and where the `utils` folder lives."
+  )
+)
+
+# Read the arguments passed
+opt <- parse_args(OptionParser(option_list = option_list))
+
+# If project root is not provided use here::here()
+if(is.null(opt$project_root)){
+  project_root <- here::here()
+} else {
+  project_root <- opt$project_root
+}
+
+# Source in set up functions
+source(file.path(project_root, "utils", "setup-functions.R"))
+
+# Check R version
+check_r_version()
+
+# Set up renv
+setup_renv(project_filepath = project_root)
+
+# Check that file extension for output file is correct
+if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
+  stop("output file name must end in .rds")
+}
+
+# Read in merged SCE -----------------------------------------------------------
+
+merged_sce <- readr::read_rds(opt$merged_sce_rds)
+
+# Integrate SCEs ---------------------------------------------------------------
+
+# Perform integration with specified method
+if ("fastMNN" %in% opt$integration_method) {
+  integrated_sce <- integrate_sces(merged_sce,
+                                   integration_method = "fastMNN",
+                                   batch_column = "library_id")
+}
+
+if ("harmony" %in% opt$integration_method) {
+  integrated_sce <- integrate_sces(merged_sce,
+                                   integration_method = "harmony",
+                                   batch_column = "library_id")
+}
+
+# Write integrated object to file ----------------------------------------------
+
+write_rds(integrated_sce, opt$output_sce_file)
+

--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -77,10 +77,8 @@ integration_methods <-  stringr::str_split(opt$integration_method, ",") %>%
   stringr::str_trim()
 
 # Check that we support the provided integration method(s)
-for (integration_method in integration_methods) {
-  if (!integration_method %in% c("fastMNN", "harmony")) {
-    stop("--integration_method must be either fastMNN, harmony, or both (comma-separated)")
-  }
+if (!all(integration_methods %in% c("fastMNN", "harmony"))) {
+  stop("--integration_method must be either fastMNN, harmony, or both (comma-separated)")
 }
 
 # Check that `library_id` is in merged SCE object


### PR DESCRIPTION
**Issue Addressed**
#344 

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR adds a `perform-integration.R` script to the `optional-integration-analysis` subdirectory to address #344 .

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->

The added `perform-integration.R` script does the following:
 - takes in a merged SCE object (output of the `merge-sce.R` script)
- takes in the desired integration method(s) with `fastMNN` and `harmony` as defaults
- uses the `scpcaTools::integrate_sces()` function to integrate by fastMNN and harmony
- saves the SCE object with integrated results separately from the merged object

**Any comments, concerns, or questions important for reviewers**
- Does the PR adequately address #344?
- Something I went back and forth on myself — should we be saving these integrated results separately from the merged object? In other words, is there reason for keeping the merged unintegrated object around or should we save the integrated results using the same filename?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)