### PR TITLE
Incorporate integration order

### DIFF
--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -28,13 +28,14 @@ option_list <- list(
     action = "store_true",
     default = FALSE,
     help = "Indicates whether or not to use the auto.merge option for `fastMNN` integration;
-    to perform auto.merge, use `--fastmnn_auto_merge`"
+    to perform auto.merge, use `--fastmnn_auto_merge` and this will override any input order"
   ),
   make_option(
     opt_str = c("--fastmnn_merge_order"),
     type = "character",
     default = NULL,
-    help = "Optional vector of library ids in the order of which they should be merged"
+    help = "Optional vector of library ids in the order of which they should be merged;
+    will only be used if --fastmnn_auto_merge is FALSE"
   ),
   make_option(
     opt_str = c("-o", "--output_sce_file"),
@@ -103,11 +104,16 @@ if(!("library_id" %in% colnames(colData(merged_sce)))){
 # Perform integration with specified method
 if ("fastMNN" %in% integration_methods) {
   # Format `fastmnn_merge_order` if provided; can only be used when auto.merge is FALSE
-  if(is.null(opt$fastmnn_auto_merge)) {
+  if(!opt$fastmnn_auto_merge) {
     if(!is.null(opt$fastmnn_merge_order)){
       fastmnn_merge_order <- stringr::str_split(opt$fastmnn_merge_order, ",") %>%
         unlist() %>%
         stringr::str_trim()
+      if(!all(colData(merged_sce)$library_id %in% fastmnn_merge_order)){
+        stop("The provided library ids do not match those in the SCE object. 
+             Please re-run and provide --fastmnn_merge_order with all library ids 
+             found in the `colData` of the SCE object.")
+      }
     }
   } else {
     fastmnn_merge_order <- NULL

--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -27,15 +27,14 @@ option_list <- list(
     opt_str = c("--fastmnn_auto_merge"),
     action = "store_true",
     default = FALSE,
-    help = "Indicates whether or not to use the auto.merge option for `fastMNN` integration.
-    To perform auto.merge, use `--fastmnn_auto_merge`."
+    help = "Indicates whether or not to use the auto.merge option for `fastMNN` integration;
+    to perform auto.merge, use `--fastmnn_auto_merge`"
   ),
   make_option(
     opt_str = c("--fastmnn_merge_order"),
     type = "character",
     default = NULL,
-    help = "Vector of library ids in the order of which they should be merged; 
-    should only be provided when using `--fastmnn_auto_merge`."
+    help = "Optional vector of library ids in the order of which they should be merged"
   ),
   make_option(
     opt_str = c("-o", "--output_sce_file"),
@@ -103,11 +102,9 @@ if(!("library_id" %in% colnames(colData(merged_sce)))){
 
 # Perform integration with specified method
 if ("fastMNN" %in% integration_methods) {
-  if(opt$fastmnn_auto_merge == TRUE) {
-    if(is.null(opt$fastmnn_merge_order)){
-      stop("The character vector with library ids in the order of which they should be merged is missing.
-           Please provide this vector using --fastmnn_merge_order or re-run without --fastmnn_auto_merge.")
-    } else {
+  # Format `fastmnn_merge_order` if provided; can only be used when auto.merge is FALSE
+  if(is.null(opt$fastmnn_auto_merge)) {
+    if(!is.null(opt$fastmnn_merge_order)){
       fastmnn_merge_order <- stringr::str_split(opt$fastmnn_merge_order, ",") %>%
         unlist() %>%
         stringr::str_trim()


### PR DESCRIPTION
**Issue Addressed**
Closes #347

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR allows us to use the `auto.merge` option for fastMNN integration, and also allows for users to provide a character vector of library ids to use as the order for integration. 

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
The following modifications were made to the `perform-integration.R` script:
- The `--fastmnn_auto_merge` argument added (default is currently false, but will be set to true using the `config.yaml` file to set the argument in the snakemake workflow in an upcoming PR)
- The `fastmnn_merge_order` argument added and logic to use this list when provided (only if `--fastmnn_auto_merge` is set to false, otherwise this argument will be NULL) 

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->
The formatting of the `fastmnn_merge_order` at line 108 was implemented because without this, I receive the following error:

```
Error in .create_tree_predefined(batches, restrict, merge.order) : 
  invalid leaf nodes specified in 'merge.order'
```

Otherwise, users would need to use `c("library02", "library01")` when implementing this argument. 
**Any comments, concerns, or questions important for reviewers**
- Does this PR correctly address what's noted on issue #347?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)