### PR TITLE
Initiate data integration report template

### DIFF
--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -1,0 +1,128 @@
+---
+params:
+  integration_group: "group01"
+  integrated_sce: "example-results/group01_integrated_sce.rds"
+  integration_method: "harmony"
+  batch_column: "library_id"
+  project_root: NULL
+  point_size: 0.7
+  seed: 2023
+  date: !r Sys.Date()
+title: "`r glue::glue('Integration analysis report for {params$integration_group}')`"
+author: "CCDL"
+date: "`r params$date`"
+output: 
+  html_document:
+    toc: true
+    toc_depth: 2
+    toc_float: true
+    number_sections: true
+    code_folding: hide
+editor_options: 
+  chunk_output_type: console
+---
+
+This notebook will plot the output of the `optional-integration-analysis/perform-integration.R` script, which allows for integration of multiple libraries.
+Here clustering was performed using the following clustering types:
+
+## Set Up
+
+```{r, setup, include=FALSE}
+knitr::opts_chunk$set(
+  message = FALSE,
+  warning = FALSE
+)
+
+# If project root is not provided use here::here() 
+if (is.null(params$project_root)) {
+  project_root <- here::here()
+} else {
+  project_root <- params$project_root
+} 
+
+# Tell knitr to knit from the project root to be able to load `renv` properly
+# This path goes into effect for SUBSEQUENT chunks, hence the need for 2 chunks
+knitr::opts_knit$set(root.dir = project_root)
+
+# Source in set up function
+source(file.path(project_root, "utils", "setup-functions.R"))
+source(file.path(project_root, "utils", "integration-functions.R"))
+```
+
+```{r, include = FALSE}
+# Load project
+setup_renv(project_filepath = project_root)
+```
+
+```{r}
+# Load libraries
+library(readr)
+library(SingleCellExperiment)
+library(miQC)
+library(ggpubr)
+library(scater)
+library(dplyr)
+
+# Set theme for plotting
+library(ggplot2)
+point_size <- params$point_size
+
+# Read in integrated object
+integrated_sce <- readr::read_rds(params$integrated_sce)
+```
+
+## Explore datasets
+
+```{r results='asis'}
+# pull out an SCE object for this section
+# all SCEs in the list should be equivalent for these calculations and plots
+sce_coldata <- colData(integrated_sce) %>% tibble::as_tibble()
+
+# helper function to count
+count_groups <- function(colname) {
+  # colname: the column of interest we should count
+  colname_sym <- rlang::sym(colname)
+  sce_coldata %>%
+    dplyr::count(!!colname_sym, name = "count")
+}
+
+# How many batches?
+n_batch_df <- count_groups(params$batch_column)
+print(
+  glue::glue("There are {nrow(n_batch_df)} total batches, with the following number of cells:")
+)
+gt::gt(n_batch_df)
+```
+
+## UMAP plots
+
+```{r, fig.width=10, fig.height=10}
+# plot UMAPs and label by batch column
+# Split up string of integration methods
+integration_methods <-  stringr::str_split(params$integration_method, ",") %>%
+  unlist() %>%
+  stringr::str_trim()
+integration_methods <- c(integration_methods, "unintegrated")
+cell_label_column <- params$batch_column
+batch_umaps <- integration_methods %>%
+  purrr::map(~ plot_integration_umap(sce = integrated_sce,
+                                     integration_method = .x,
+                                     cell_label_column = params$batch_column,
+                                     legend_title = "Batches",
+                                     seed = params$seed))
+batch_legend <- cowplot::get_legend(batch_umaps[[1]])
+  
+ggpubr::ggarrange(plotlist = batch_umaps,
+                  common.legend = TRUE, 
+                  legend = "right",
+                  legend.grob = batch_legend, 
+                  ncol = 2, 
+                  nrow = 4) 
+```
+
+## Session info
+<details>
+<summary>R session information</summary>
+```{r}
+sessionInfo()
+```

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -60,11 +60,8 @@ setup_renv(project_filepath = project_root)
 
 ```{r}
 # Load libraries
-library(readr)
 library(SingleCellExperiment)
-library(miQC)
 library(ggpubr)
-library(scater)
 library(dplyr)
 
 # Set theme for plotting

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -46,6 +46,11 @@ knitr::opts_knit$set(root.dir = project_root)
 # Source in set up function
 source(file.path(project_root, "utils", "setup-functions.R"))
 source(file.path(project_root, "utils", "integration-functions.R"))
+
+# Install `gt` package
+if(!("gt" %in% installed.packages())){
+  install.packages("gt", repos = "http://cran.us.r-project.org")
+}
 ```
 
 ```{r, include = FALSE}

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -22,8 +22,7 @@ editor_options:
   chunk_output_type: console
 ---
 
-This notebook will plot the output of the `optional-integration-analysis/perform-integration.R` script, which allows for integration of multiple libraries.
-Here clustering was performed using the following clustering types:
+This notebook includes a summary of a single integrated dataset produced from running the data integration workflow.
 
 ## Set Up
 
@@ -67,6 +66,10 @@ library(dplyr)
 library(ggplot2)
 point_size <- params$point_size
 
+# Check that integrated object file exists
+if(!file.exists(params$integrated_sce)){
+  stop(paste(params$integrated_sce, "does not exist."))
+}
 # Read in integrated object
 integrated_sce <- readr::read_rds(params$integrated_sce)
 ```
@@ -76,39 +79,45 @@ integrated_sce <- readr::read_rds(params$integrated_sce)
 ```{r results='asis'}
 # pull out an SCE object for this section
 # all SCEs in the list should be equivalent for these calculations and plots
-sce_coldata <- colData(integrated_sce) %>% tibble::as_tibble()
-
-# helper function to count
-count_groups <- function(colname) {
-  # colname: the column of interest we should count
-  colname_sym <- rlang::sym(colname)
-  sce_coldata %>%
-    dplyr::count(!!colname_sym, name = "count")
-}
+sce_coldata <- colData(integrated_sce) %>% 
+  tibble::as_tibble()
 
 # How many batches?
-n_batch_df <- count_groups(params$batch_column)
+colname_sym <- rlang::sym(params$batch_column)
+n_batch_df <- sce_coldata %>%
+  dplyr::count(!!colname_sym, name = "count")
+
 print(
-  glue::glue("There are {nrow(n_batch_df)} total batches, with the following number of cells:")
+  glue::glue("There are {nrow(n_batch_df)} libraries stored in the merged and integrated dataset, with the following number of cells:")
 )
 gt::gt(n_batch_df)
 ```
 
 ## UMAP plots
 
+```{r}
+# create batch label vector
+batch_plot_labels <- n_batch_df %>%
+  dplyr::mutate(label = paste0(!!colname_sym, " (N=", count, ")")) %>%
+  dplyr::pull(label)
+```
+
+
 ```{r, fig.width=10, fig.height=10}
 # plot UMAPs and label by batch column
-# Split up string of integration methods
+# split up string of integration methods
 integration_methods <-  stringr::str_split(params$integration_method, ",") %>%
   unlist() %>%
   stringr::str_trim()
 integration_methods <- c(integration_methods, "unintegrated")
-cell_label_column <- params$batch_column
+
 batch_umaps <- integration_methods %>%
   purrr::map(~ plot_integration_umap(sce = integrated_sce,
                                      integration_method = .x,
                                      cell_label_column = params$batch_column,
-                                     legend_title = "Batches",
+                                     legend_title = "Library",
+                                     plot_title = .x,
+                                     legend_labels = batch_plot_labels,
                                      seed = params$seed))
 batch_legend <- cowplot::get_legend(batch_umaps[[1]])
   

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -2,7 +2,7 @@
 params:
   integration_group: "group01"
   integrated_sce: "example-results/group01_integrated_sce.rds"
-  integration_method: "harmony"
+  integration_method: "fastMNN,harmony"
   batch_column: "library_id"
   project_root: NULL
   point_size: 0.7
@@ -115,9 +115,8 @@ batch_legend <- cowplot::get_legend(batch_umaps[[1]])
 ggpubr::ggarrange(plotlist = batch_umaps,
                   common.legend = TRUE, 
                   legend = "right",
-                  legend.grob = batch_legend, 
                   ncol = 2, 
-                  nrow = 4) 
+                  nrow = 2) 
 ```
 
 ## Session info

--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -127,23 +127,24 @@ if ("fastMNN" %in% integration_methods) {
                                    integration_method = "fastMNN",
                                    batch_column = "library_id",
                                    auto.merge = opt$fastmnn_auto_merge,
-                                   merge.order = fastmnn_merge_order) %>%
-    perform_dim_reduction(prefix = "fastMNN")
+                                   merge.order = fastmnn_merge_order)
   
-  reducedDim(merged_sce, "fastMNN_PCA") <- reducedDim(fastMNN_integrated_sce, "fastMNN_PCA")
-  reducedDim(merged_sce, "fastMNN_UMAP") <- reducedDim(fastMNN_integrated_sce, "fastMNN_UMAP")
+  merged_sce <- add_integrated_pcs(merged_sce,
+                                   integrated_pcs = reducedDim(fastMNN_integrated_sce, "fastMNN_PCA"),
+                                   integration_method = "fastMNN")
   
 }
 
 if ("harmony" %in% integration_methods) {
   harmony_integrated_sce <- integrate_sces(merged_sce,
                                    integration_method = "harmony",
-                                   batch_column = "library_id") %>%
-    perform_dim_reduction(prefix = "harmony")
+                                   batch_column = "library_id")
   
-  reducedDim(merged_sce, "harmony_PCA") <- reducedDim(harmony_integrated_sce, "harmony_PCA")
-  reducedDim(merged_sce, "harmony_UMAP") <- reducedDim(harmony_integrated_sce, "harmony_UMAP")
+  merged_sce <- add_integrated_pcs(merged_sce,
+                                   integrated_pcs = reducedDim(harmony_integrated_sce, "harmony_PCA"),
+                                   integration_method = "harmony")
 }
+
 
 # Write integrated object to file ----------------------------------------------
 

--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -127,14 +127,14 @@ if ("fastMNN" %in% integration_methods) {
                                    batch_column = "library_id",
                                    auto.merge = opt$fastmnn_auto_merge,
                                    merge.order = fastmnn_merge_order)
-  scater::runUMAP(integrated_sce, dimred = "fastMNN_PCA", name = "fastMNN_UMAP")
+  integrated_sce <- scater::runUMAP(integrated_sce, dimred = "fastMNN_PCA", name = "fastMNN_UMAP")
 }
 
 if ("harmony" %in% integration_methods) {
   integrated_sce <- integrate_sces(merged_sce,
                                    integration_method = "harmony",
                                    batch_column = "library_id")
-  scater::runUMAP(integrated_sce, dimred = "harmony_PCA", name = "harmony_UMAP")
+  integrated_sce <- scater::runUMAP(integrated_sce, dimred = "harmony_PCA", name = "harmony_UMAP")
 }
 
 # Write integrated object to file ----------------------------------------------

--- a/utils/integration-functions.R
+++ b/utils/integration-functions.R
@@ -1,0 +1,96 @@
+## Custom functions for data integration.
+
+# #### USAGE
+# This script is intended to be sourced in the script as follows:
+#
+# source(file.path("utils", "integration-functions.R"))
+
+plot_umap_panel <- function(sce,
+                            cell_label_column,
+                            umap_name,
+                            plot_colors,
+                            plot_title = NULL, 
+                            legend_title = NULL,
+                            legend_labels = NULL,
+                            seed = NULL){
+  
+  set.seed(seed)
+  
+  # check that plot_colors is equal to the number of categories present in the cell label column
+  color_categories <- unique(colData(sce)[,cell_label_column])
+  if(length(plot_colors) != length(color_categories)){
+    stop("Number of colors provided must be equal to the number of categories used to classify cells in
+         the specified cell_label_column.")
+  }
+  
+  # randomly shuffle cells prior to plotting
+  col_order <- sample(ncol(sce))
+  shuffled_sce <- sce[,col_order]
+  
+  # create umap and label with provided cell label column
+  umap <- scater::plotReducedDim(shuffled_sce,
+                                 dimred = umap_name,
+                                 colour_by = cell_label_column,
+                                 point_size = 0.1,
+                                 point_alpha = 0.4) +
+    scale_color_manual(values = plot_colors, 
+                       name = legend_title, 
+                       labels = legend_labels) +
+    # relabel legend and resize dots
+    guides(color = guide_legend(override.aes = list(size = 3),
+                                label.theme = element_text(size = 16))) +
+    theme(legend.position = "none",
+          text = element_text(size = 14),
+          legend.title = element_text(size = 16)) +
+    labs(
+      title = plot_title
+    )
+  
+  return(umap)
+}
+
+plot_integration_umap <- function(sce,
+                                  integration_method,
+                                  cell_label_column,
+                                  include_legend_counts = TRUE,
+                                  legend_title = NULL, 
+                                  legend_labels = NULL,
+                                  plot_colors = NULL,
+                                  seed = NULL) {
+  
+  set.seed(seed)
+  
+  # check that column to label cells by is present in colData
+  if(!cell_label_column %in% colnames(colData(sce))){
+    stop("Provided cell_label_column should be present in the SCE object.")
+  }
+  
+  
+  # Define colors if not provided, or if provided check the size
+  if (is.null(plot_colors)) {
+    num_colors <- length(unique(sce[[cell_label_column]]))
+    plot_colors <- rainbow(num_colors)    
+  } else {
+    if (!(length(plot_colors)) == length(unique(sce[[cell_label_column]]))) {
+      stop("The number of provided colors does not match the number of labels.")
+    }
+  }
+  
+  if(integration_method == "unintegrated"){
+    umap_name <- "UMAP"
+  } else {
+    # grab dim reduction name to use for plotting
+    umap_name <- paste0(integration_method, "_UMAP")
+  }
+  
+  umap <- plot_umap_panel(sce = sce,
+                          cell_label_column,
+                          umap_name = umap_name, 
+                          plot_colors = plot_colors,
+                          plot_title = integration_method,
+                          legend_title = legend_title,
+                          legend_labels = legend_labels,
+                          seed = seed)
+  
+  return(umap)
+}

--- a/utils/integration-functions.R
+++ b/utils/integration-functions.R
@@ -8,13 +8,25 @@
 plot_integration_umap <- function(sce,
                                   integration_method,
                                   cell_label_column,
-                                  include_legend_counts = TRUE,
                                   legend_title = NULL, 
                                   legend_labels = NULL,
                                   plot_colors = NULL,
                                   plot_title = NULL,
                                   seed = NULL) {
   
+  # Purpose: Generate UMAP plots using integration results from a SingleCellExperiment object 
+  
+  # Args:
+  #   sce: SingleCellExperiment object containing integration results
+  #   integration_method: the method used to perform integration. i.e. "fastMNN", "harmony"
+  #   cell_label_column: the name of the colData column to label cells by
+  #   legend_title: the title of the plot legend
+  #   legend_labels: a vector of names to use to label the legend
+  #   plot_colors: a vector of colors to use when plotting; default is NULL
+  #   plot_title: the title of the plot
+  #   seed: an integer to set the seed as for reproducibility
+  
+  # set seed for reproducibility 
   set.seed(seed)
   
   # check that column to label cells by is present in colData
@@ -69,6 +81,13 @@ plot_integration_umap <- function(sce,
 add_integrated_pcs <- function(merged_sce,
                                integrated_pcs,
                                integration_method){  
+  # Purpose: Add integrated PCs as calculated by the integration method to the 
+  #          merged SingleCellExperiment object 
+  
+  # Args:
+  #   merged_sce: a merged SingleCellExperiment object
+  #   integrated_pcs: the full set of integrated pcs
+  #   integration_method: the method used to perform integration. i.e. "fastMNN", "harmony"
   
   # check that integration method is provided
   if(is.null(integration_method)){

--- a/utils/integration-functions.R
+++ b/utils/integration-functions.R
@@ -14,7 +14,7 @@ plot_integration_umap <- function(sce,
                                   plot_title = NULL,
                                   seed = NULL) {
   
-  # Purpose: Generate UMAP plots using integration results from a SingleCellExperiment object 
+  # Purpose: Generate UMAP plots for a merged or integrated SingleCellExperiment object containing multiple batches
   
   # Args:
   #   sce: SingleCellExperiment object containing integration results

--- a/utils/integration-functions.R
+++ b/utils/integration-functions.R
@@ -94,3 +94,21 @@ plot_integration_umap <- function(sce,
   
   return(umap)
 }
+
+perform_dim_reduction <- function(merged_sce,
+                                  prefix = NULL){
+  
+  # create pca and umap names
+  pca_name <- "PCA"
+  umap_name <- "UMAP"
+  if(!is.null(prefix)){
+    pca_name <- paste(prefix, pca_name, sep = "_")
+    umap_name <- paste(prefix, umap_name, sep = "_")
+  }
+  
+  # add UMAP
+  merged_sce <- scater::runUMAP(merged_sce, dimred = pca_name, name = umap_name)
+  
+  return(merged_sce)
+  
+}


### PR DESCRIPTION
**Issue Addressed**
Closes #351

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR initiates the data integration report template.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
A `integration-report-template.Rmd` file was added to the `optional-integration-analysis` module. This template currently contains the following:
- a breakdown of number of batches and number of cells per batch
- UMAPs for each of the integration methods being compared (including unintegrated)

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->
It looks like we may need to tweak the `perform-integration.R` script here as well, as I tried running the template using both `"fastMNN, harmony"` as the integration methods but only the harmony results were found in the integrated SCE object

**Any comments, concerns, or questions important for reviewers**
- Does this tackle #351 as you would expect?

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)