### PR TITLE
Add within-batch ARI plots to report template

### DIFF
--- a/config/integration_config.yaml
+++ b/config/integration_config.yaml
@@ -8,3 +8,4 @@ integration_project_metadata: "example-data/project-metadata/example-integration
 threads: 1 # number of multiprocessing threads to use
 integration_method: "fastMNN,harmony" # method(s) to be used for integration
 batch_column: "library_id" # the name of the SCE column that contains batch labels
+cell_id_column: "cell_id" # the name of the SCE column variable indicating the original cell barcode

--- a/integration.snakefile
+++ b/integration.snakefile
@@ -77,7 +77,8 @@ rule generate_integration_report:
                             params = list(integration_group = '{wildcards.group}',
                                           integrated_sce = '{input.integrated_sce}',
                                           integration_method = '{config[integration_method]}',
-                                          batch_column = '{config[batch_column]}'),
+                                          batch_column = '{config[batch_column]}',
+                                          cell_id_column = '{config[cell_id_column]}'),
                            envir = new.env())
         " &> {log}
         """

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -177,7 +177,9 @@ Within-batch ARI values close to 1 indicate that biological heterogeneity has be
 ```{r}
 # List of SCE filepaths
 input_metadata <- readr::read_tsv(params$input_metadata_tsv)
-sce_files <- input_metadata$processed_sce_filepath
+sce_files <- input_metadata |>
+  dplyr::filter(integration_group == params$integration_group) |>
+  dplyr::pull(processed_sce_filepath)
 # Read in list of SCEs
 sce_list <- purrr::map(sce_files, readr::read_rds) |>
   purrr::set_names(input_metadata$library_id)
@@ -191,14 +193,23 @@ within_batch_ari_df <-
     batch_column = params$batch_column,
     BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
     seed = params$seed
-  )
-
-within_batch_ari_df$ari <- as.numeric(within_batch_ari_df$ari)
+ ) |>
+  dplyr::mutate(ari = as.numeric(ari))
                                                   
 ```
 
 ```{r}
-ggplot(within_batch_ari_df, aes(x = pc_name , y = ari, color = batch_id)) +
+within_batch_ari_plot <- within_batch_ari_df |>
+  dplyr::mutate(
+    integration_method = dplyr::if_else(
+      pc_name == "PCA",
+      "Pre-Integration",
+      stringr::str_remove(pc_name, "_PCA")
+    ),
+    integration_method_factor = forcats::fct_relevel(integration_method, "Pre-Integration")
+  ) |>
+  ggplot() +
+  aes(x = pc_name , y = ari, color = batch_id) +
   geom_point() +
   ggforce::geom_sina() +
   # add median point to plot
@@ -214,9 +225,15 @@ ggplot(within_batch_ari_df, aes(x = pc_name , y = ari, color = batch_id)) +
     geom = "pointrange",
     size = 0.4
   ) +
+  guides(color = guide_legend(
+    override.aes = list(size = 3),
+    label.theme = element_text(size = 12)
+  )) +
   labs(x = "Integration method",
        y = "ARI",
        color = "Batch")
+
+within_batch_ari_plot
 ```
 
 ## Session info

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -176,9 +176,9 @@ Within-batch ARI values close to 1 indicate that biological heterogeneity has be
 
 ```{r}
 # List of SCE filepaths
-input_metadata <- readr::read_tsv(params$input_metadata_tsv)
+input_metadata <- readr::read_tsv(params$input_metadata_tsv) |> 
+  dplyr::filter(integration_group == params$integration_group)
 sce_files <- input_metadata |>
-  dplyr::filter(integration_group == params$integration_group) |>
   dplyr::pull(processed_sce_filepath)
 # Read in list of SCEs
 sce_list <- purrr::map(sce_files, readr::read_rds) |>
@@ -209,8 +209,7 @@ within_batch_ari_plot <- within_batch_ari_df |>
     integration_method_factor = forcats::fct_relevel(integration_method, "Pre-Integration")
   ) |>
   ggplot() +
-  aes(x = pc_name , y = ari, color = batch_id) +
-  geom_point() +
+  aes(x = integration_method_factor, y = ari, color = batch_id) +
   ggforce::geom_sina() +
   # add median point to plot
   stat_summary(

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -190,13 +190,40 @@ pc_names <-  stringr::str_split(params$integration_method, ",") %>%
 pc_names <- c(pc_names, "PCA")
 
 # Calculate within-batch ARI values
-within_batch_ari_df <- scpcaTools::calculate_within_batch_ari(individual_sce_list = sce_list,
-                                                  pc_names = pc_names,
-                                                  merged_sce = integrated_sce,
-                                                  batch_column = params$batch_column,
-                                                  BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
-                                                  seed = params$seed)
+within_batch_ari_df <-
+  scpcaTools::calculate_within_batch_ari(
+    individual_sce_list = sce_list,
+    pc_names = pc_names,
+    merged_sce = integrated_sce,
+    batch_column = params$batch_column,
+    BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
+    seed = params$seed
+  )
+
+within_batch_ari_df$ari <- as.numeric(within_batch_ari_df$ari)
                                                   
+```
+
+```{r}
+ggplot(within_batch_ari_df, aes(x = pc_name , y = ari, color = batch_id)) +
+  geom_point() +
+  ggforce::geom_sina() +
+  # add median point to plot
+  stat_summary(
+    color = "red",
+    fun = "median",
+    fun.min = function(x) {
+      quantile(x, 0.25)
+    },
+    fun.max = function(x) {
+      quantile(x, 0.75)
+    },
+    geom = "pointrange",
+    size = 0.4
+  ) +
+  labs(x = "Integration method",
+       y = "ARI",
+       color = "Batch")
 ```
 
 ## Session info

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -1,6 +1,7 @@
 ---
 params:
   integration_group: "group01"
+  input_metadata_tsv: "example-data/project-metadata/example-integration-library-metadata.tsv"
   integrated_sce: "example-results/group01_integrated_sce.rds"
   integration_method: "fastMNN,harmony"
   batch_column: "library_id"
@@ -129,6 +130,42 @@ ggpubr::ggarrange(plotlist = batch_umaps,
                   ncol = 2, 
                   nrow = 2) 
 ```
+
+## Within-batch ARI plots
+
+Below we calculate the within-batch ARI values.
+The metric measures how well a given integration method preserves biological heterogeneity by comparing pre- and post-integration clustering assignments for each library.
+We take each original SCE object, prior to any merging, and perform graph-based clustering.
+The same clustering is then performed on the integrated object.
+For each library that is present in the integrated object, the original cluster assignments are compared to the cells’ new cluster assignments post integration by calculating the ARI between these two cluster assignments.
+Within-batch ARI values close to 1 indicate that biological heterogeneity has been preserved.
+
+```{r}
+# List of SCE filepaths
+input_metadata <- readr::read_tsv(params$input_metadata_tsv)
+sce_files <- input_metadata$processed_sce_filepath
+# Read in list of SCEs
+sce_list <- purrr::map(sce_files, readr::read_rds) |>
+  purrr::set_names(input_metadata$library_id)
+
+# Prepare vector of PC names
+pc_names <-  stringr::str_split(params$integration_method, ",") %>%
+  unlist() |>
+  stringr::str_trim() |>
+  purrr::map(\(method) paste(method, "PCA", sep = "_"))
+# Set PC name for the unintegrated
+pc_names <- c(pc_names, "PCA")
+
+# Calculate within-batch ARI values
+within_batch_ari_df <- scpcaTools::calculate_within_batch_ari(individual_sce_list = sce_list,
+                                                  pc_names = pc_names,
+                                                  merged_sce = integrated_sce,
+                                                  batch_column = params$batch_column,
+                                                  BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
+                                                  seed = params$seed)
+                                                  
+```
+
 
 ## Session info
 <details>

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -5,6 +5,7 @@ params:
   integrated_sce: "example-results/group01_integrated_sce.rds"
   integration_method: "fastMNN,harmony"
   batch_column: "library_id"
+  cell_id_column: "cell_id"
   project_root: NULL
   point_size: 0.7
   seed: 2023
@@ -191,6 +192,7 @@ within_batch_ari_df <-
     pc_names = pc_names,
     merged_sce = integrated_sce,
     batch_column = params$batch_column,
+    cell_id_column = params$cell_id_column,
     BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
     seed = params$seed
  ) |>

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -215,7 +215,7 @@ within_batch_ari_plot <- within_batch_ari_df |>
   ggforce::geom_sina() +
   # add median point to plot
   stat_summary(
-    color = "red",
+    color = "black",
     fun = "median",
     fun.min = function(x) {
       quantile(x, 0.25)
@@ -224,7 +224,7 @@ within_batch_ari_plot <- within_batch_ari_df |>
       quantile(x, 0.75)
     },
     geom = "pointrange",
-    size = 0.4
+    size = 0.2
   ) +
   guides(color = guide_legend(
     override.aes = list(size = 3),

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -182,14 +182,6 @@ sce_files <- input_metadata$processed_sce_filepath
 sce_list <- purrr::map(sce_files, readr::read_rds) |>
   purrr::set_names(input_metadata$library_id)
 
-# Prepare vector of PC names
-pc_names <-  stringr::str_split(params$integration_method, ",") %>%
-  unlist() |>
-  stringr::str_trim() |>
-  purrr::map(\(method) paste(method, "PCA", sep = "_"))
-# Set PC name for the unintegrated
-pc_names <- c(pc_names, "PCA")
-
 # Calculate within-batch ARI values
 within_batch_ari_df <-
   scpcaTools::calculate_within_batch_ari(

--- a/renv.lock
+++ b/renv.lock
@@ -1504,6 +1504,22 @@
       ],
       "Hash": "e80750aec5717dedc019ad7ee40e4a7c"
     },
+    "forcats": {
+      "Package": "forcats",
+      "Version": "1.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "glue",
+        "lifecycle",
+        "magrittr",
+        "rlang",
+        "tibble"
+      ],
+      "Hash": "1a0a9a3d5083d0d573c4214576f1e690"
+    },
     "foreach": {
       "Package": "foreach",
       "Version": "1.5.2",
@@ -2446,7 +2462,7 @@
         "utils",
         "withr"
       ],
-      "Hash": "6b0c222c5071efe0f3baf3dae9aa40e2"
+      "Hash": "a7f498a1b2a4a6816148e498509f6e1d"
     },
     "plogr": {
       "Package": "plogr",
@@ -2679,7 +2695,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "227045be9aee47e6dda9bb38ac870d67"
+      "Hash": "63d15047eb239f95160112bcadc4fcb9"
     },
     "renv": {
       "Package": "renv",
@@ -2930,7 +2946,7 @@
       "RemoteRepo": "scpcaTools",
       "RemoteUsername": "AlexsLemonade",
       "RemoteRef": "main",
-      "RemoteSha": "47644e14efbb9d37db37c8e08324f53dc769763e",
+      "RemoteSha": "7982096108d031510eb925d1d6d600caf91a4c7f",
       "Requirements": [
         "BiocGenerics",
         "DropletUtils",
@@ -2955,7 +2971,7 @@
         "tidyr",
         "tximport"
       ],
-      "Hash": "ad60f57690048e7d564f31dc9305c665"
+      "Hash": "0d2f93694b0a13151934658cfd3bf5ad"
     },
     "scran": {
       "Package": "scran",
@@ -3076,7 +3092,7 @@
         "withr",
         "xtable"
       ],
-      "Hash": "c2eae3d8c670fa9dfa35a12066f4a1d5"
+      "Hash": "f7f201522eedbc95f10ef323b100ff29"
     },
     "sitmo": {
       "Package": "sitmo",

--- a/renv.lock
+++ b/renv.lock
@@ -2946,7 +2946,7 @@
       "RemoteRepo": "scpcaTools",
       "RemoteUsername": "AlexsLemonade",
       "RemoteRef": "main",
-      "RemoteSha": "7982096108d031510eb925d1d6d600caf91a4c7f",
+      "RemoteSha": "39dbed38b3b906b132783f45b3e3a3a7a85bc729",
       "Requirements": [
         "BiocGenerics",
         "DropletUtils",
@@ -2971,7 +2971,7 @@
         "tidyr",
         "tximport"
       ],
-      "Hash": "0d2f93694b0a13151934658cfd3bf5ad"
+      "Hash": "ac287aa860a17a5fe3447762bcffaffc"
     },
     "scran": {
       "Package": "scran",


### PR DESCRIPTION
**Issue Addressed**
Closes #354

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
The purpose of this PR is to add function implementation to calculate within-batch ARI values to the integration report, and to add the plots to display the calculated values.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->

A within-batch ARI plots section was added to the integration report template which implements the calculate_within_batch_ari() function from `scpcaTools` 

**Were there any other solutions that you tried?**
<!--Did you try alternative solutions that did or didn't work before choosing this one? Why did you choose this route?-->

**Any comments, concerns, or questions important for reviewers**
**Note**: When trying to knit/run the template locally, I am receiving an error that object `batch_ids` cannot be found -- I tried adjusting the `RemoteSha` hash in the lock file to the latest commit for scpcaTools (which fixes the batch ids issue) but still receive the same error. I also tried running the `setup_envs.sh` script once again but that did not work. Any suggestions @allyhawkins @jashapiro?

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)