### PR TITLE
Add expected input and output to integration docs

### DIFF
--- a/additional-docs/additional-parameters.md
+++ b/additional-docs/additional-parameters.md
@@ -95,16 +95,17 @@ The following gene mapping parameters found in the `config/goi_config.yaml` file
 ## Integration analysis parameters
 
 The [configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html), `config/integration_config.yaml` sets the defaults for all parameters needed to run the data integration workflow.
-It is **not required** to alter these parameters to run the workflow, but if you would like to change the integration method(s) or the number of multi-processing threads to use, you can do so by changing these parameters via a text editor of your choice or at the command line per our documentation [here](./command-line-options.md). 
+It is **not required** to alter these parameters to run the workflow.
+If you would like to change the integration method(s) or the number of multi-processing threads to use, you can do so by changing these parameters via a text editor of your choice or at the command line per our documentation [here](./command-line-options.md). 
 
 The parameters found in the `config/integration_config.yaml` file can be optionally modified and are as follows:
 
 | Parameter        | Description | Default value |
 |------------------|-------------|---------------|
 | `threads` | the number of multiprocessing threads to use | 1 |
-| `integration_method` | the method(s) to be used for integration | `"fastMNN,harmony"` |
-| `batch_column` | the name of the `SingleCellExperiment` column that indicates the grouping of interest; this will generally be batches or cell types | `"library_id"` |
-| `cell_id_column` | the name of the `SingleCellExperiment` column that contains the cell barcodes | `"cell_id"` |
+| `integration_method` | the method(s) to be used for integration; to include multiple integration methods use a comma separated list. Currently, the workflow only supports `fastMNN` or `harmony`. | `"fastMNN,harmony"` |
+| `batch_column` | the name of the column in the `SingleCellExperiment` object indicating the original library each cell was derived from | `"library_id"` |
+| `cell_id_column` | the name of the column in the `SingleCellExperiment` object containing the cell barcode | `"cell_id"` |
 
 |[View Integration Config File](../config/integration_config.yaml)|
 |---|

--- a/additional-docs/additional-parameters.md
+++ b/additional-docs/additional-parameters.md
@@ -12,6 +12,7 @@ These parameters are all included in the config files and can optionally be alte
   - [Dimensionality reduction and clustering parameters](#dimensionality-reduction-and-clustering-parameters)
 - [Clustering analysis parameters](#clustering-analysis-parameters)
 - [Genes of interest analysis parameters](#genes-of-interest-analysis-parameters)
+- [Integration analysis parameters](#integration-analysis-parameters)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/additional-docs/additional-parameters.md
+++ b/additional-docs/additional-parameters.md
@@ -90,3 +90,20 @@ The following gene mapping parameters found in the `config/goi_config.yaml` file
 
 |[View Genes of Interest Config File](../config/goi_config.yaml)|
 |---|
+
+## Integration analysis parameters
+
+The [configuration file](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html), `config/integration_config.yaml` sets the defaults for all parameters needed to run the data integration workflow.
+It is **not required** to alter these parameters to run the workflow, but if you would like to change the integration method(s) or the number of multi-processing threads to use, you can do so by changing these parameters via a text editor of your choice or at the command line per our documentation [here](./command-line-options.md). 
+
+The parameters found in the `config/integration_config.yaml` file can be optionally modified and are as follows:
+
+| Parameter        | Description | Default value |
+|------------------|-------------|---------------|
+| `threads` | the number of multiprocessing threads to use | 1 |
+| `integration_method` | the method(s) to be used for integration | `"fastMNN,harmony"` |
+| `batch_column` | the name of the `SingleCellExperiment` column that indicates the grouping of interest; this will generally be batches or cell types | `"library_id"` |
+| `cell_id_column` | the name of the `SingleCellExperiment` column that contains the cell barcodes | `"cell_id"` |
+
+|[View Integration Config File](../config/integration_config.yaml)|
+|---|

--- a/integration.snakefile
+++ b/integration.snakefile
@@ -17,9 +17,6 @@ else:
 
 rule target:
     input:
-        expand(os.path.join(config["results_dir"], "{group}_merged_sce.rds"),
-               zip,
-               group = GROUP),
         expand(os.path.join(config["results_dir"], "{group}_integrated_sce.rds"),
                zip,
                group = GROUP),
@@ -31,7 +28,7 @@ rule merge_sces:
     input:
         config["integration_project_metadata"]
     output:
-        os.path.join(config["results_dir"], "{group}_merged_sce.rds")
+        temp(os.path.join(config["results_dir"], "{group}_merged_sce.rds"))
     log: os.path.join("logs", config["results_dir"], "{group}_merge_sce.log")
     conda: "envs/scpca-renv.yaml"
     shell:

--- a/optional-integration-analysis/README.md
+++ b/optional-integration-analysis/README.md
@@ -129,7 +129,7 @@ example_results
 └── <integration_group>_merged_sce.rds
 ```
 
-You can also download a ZIP file with an example of the output from running the data integration workflow, including the summary HTML report, processed `SingleCellExperiment` objects stored as RDS files, and the clustering statistics saved as TSV files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/integration_example_results.zip).
+You can also download a ZIP file with an example of the output from running the data integration workflow, including the summary HTML report and the integrated `SingleCellExperiment` object stored as an RDS file, [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/integration_example_results.zip).
 
 ### What to expect in the output `SingleCellExperiment` object
 

--- a/optional-integration-analysis/README.md
+++ b/optional-integration-analysis/README.md
@@ -15,7 +15,7 @@ The merged objects contain the raw and normalized counts for all included librar
 - [Configure config file](#configure-config-file)
 - [Running the workflow](#running-the-workflow)
 - [Expected output](#expected-output)
-  - [What to expect in the output `SingleCellExperiment` object](#what-to-expect-in-the-output-singlecellexperiment-object)
+  - [What to expect in the integrated `SingleCellExperiment` object](#what-to-expect-in-the-integrated-singlecellexperiment-object)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -117,8 +117,8 @@ See our [command line options](../additional-docs/command-line-options.md) docum
 
 For each provided `integration_group`, the workflow will return two files saved in the `results_dir` specified in the config file:
 
-1. The `<integration_group>_integrated_sce.rds` file containing the `SingleCellExperiment` object that has integrated data stored for each `integration_method` as specified in the project metadata.
-2. The `<integration_group>_integration_report.html` file, which is the summary html report with plots containing and comparing the data integration results.
+1. The `<integration_group>_integrated_sce.rds` file containing the `SingleCellExperiment` object containing batch-corrected embeddings for each `integration_method` specified in the project metadata.
+2. The `<integration_group>_integration_report.html` file is a summary html report containing plots that summarize the data integration results.
 
 Below is an example of the nested file structure you can expect.
 
@@ -134,8 +134,8 @@ You can also download a ZIP file with an example of the output from running the 
 
 In the [`reducedDim`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#dimensionality-reduction-results) of the integrated `SingleCellExperiment` object, you can find the following:
 
-- Integrated results stored in the reduced dimensions and named using the associated type of integration performed.
-For example, where `fastMNN` is the type of integration performed, the PCA integration results are stored in `fastMNN_PCA` and can be accessed using `reducedDim(sce, "fastMNN_PCA")`.
+Batch-corrected embeddings stored in the reduced dimensions and named using the associated type of integration performed.
+For example, if `fastMNN` is the type of integration performed, the PCA integration results are stored in `fastMNN_PCA` and can be accessed using `reducedDim(sce, "fastMNN_PCA")`.
 The UMAP results can similary be accessed using `reducedDim(sce, "fastMNN_UMAP")`.
 
 You can find more information on the above in the [processing information documentation](../additional-docs/processing-information.md).

--- a/optional-integration-analysis/README.md
+++ b/optional-integration-analysis/README.md
@@ -45,7 +45,8 @@ Package dependencies for the analysis workflows in this repository are managed u
 
 To run this workflow, you will need to provide:
 
-1. Two or more RDS files containing normalized [output `SingleCellExperiment` objects](../README.md#expected-output) from the core dowstream analyses workflow or the processed `SingleCellExperiment` objects downloaded from the ScPCA portal (found in the `_processed.rds` file).
+1. Two or more RDS files containing normalized [`SingleCellExperiment` objects](../README.md#expected-output).
+These can be objects output from the core dowstream analyses workflow or the processed `SingleCellExperiment` objects downloaded from the ScPCA portal (found in the `_processed.rds` file).
 Each `SingleCellExperiment` object must contain a log-normalized counts matrix in an assay named `logcounts`.
 2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, including `sample_id`, `library_id`, `processed_sce_filepath`, and `integration_group` (see more on this in the ["Create metadata file" section](#create-metadata-file) and an example of this metadata file [here](../project-metadata/example-integration-library-metadata.tsv)).
 
@@ -114,29 +115,28 @@ See our [command line options](../additional-docs/command-line-options.md) docum
 
 ## Expected output
 
-For each provided `integration_group`, the workflow will return three files in the `results_dir` specified in the config file:
+For each provided `integration_group`, the workflow will return two files saved in the `results_dir` specified in the config file:
 
-1. The `_merged_sce.rds` file containing the `SingleCellExperiment` object that results from merging the individual `SingleCellExperiment` objects specified in the project metadata.
-2. The `_integrated_sce.rds` file containing the `SingleCellExperiment` object that has integrated data stored for each `integration_method` as specified in the project metadata.
-2. The `_integration_report.html` file, which is the summary html report with plots containing and comparing the data integration results.
+1. The `<integration_group>_integrated_sce.rds` file containing the `SingleCellExperiment` object that has integrated data stored for each `integration_method` as specified in the project metadata.
+2. The `<integration_group>_integration_report.html` file, which is the summary html report with plots containing and comparing the data integration results.
 
 Below is an example of the nested file structure you can expect.
 
 ```
 example_results
 ├── <integration_group>_integrated_sce.rds
-├── <integration_group>_integration_report.html
-└── <integration_group>_merged_sce.rds
+└── <integration_group>_integration_report.html
 ```
 
 You can also download a ZIP file with an example of the output from running the data integration workflow, including the summary HTML report and the integrated `SingleCellExperiment` object stored as an RDS file, [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/integration_example_results.zip).
 
-### What to expect in the output `SingleCellExperiment` object
+### What to expect in the integrated `SingleCellExperiment` object
 
-In the [`reducedDim`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#dimensionality-reduction-results) of the integrated output `SingleCellExperiment` object, you can find the following:
+In the [`reducedDim`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#dimensionality-reduction-results) of the integrated `SingleCellExperiment` object, you can find the following:
 
 - Integrated results stored in the reduced dimensions and named using the associated type of integration performed.
-For example, where `fastMNN` is the type of integration performed, the integration results are stored in `fastMNN_PCA` and can be accessed using `reducedDim(sce, "fastMNN_PCA")`.
+For example, where `fastMNN` is the type of integration performed, the PCA integration results are stored in `fastMNN_PCA` and can be accessed using `reducedDim(sce, "fastMNN_PCA")`.
+The UMAP results can similary be accessed using `reducedDim(sce, "fastMNN_UMAP")`.
 
 You can find more information on the above in the [processing information documentation](../additional-docs/processing-information.md).
 

--- a/optional-integration-analysis/README.md
+++ b/optional-integration-analysis/README.md
@@ -38,6 +38,16 @@ R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
 If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
 Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which can be installed independently if desired, but we recommend using Snakemake's conda integration to set up the R environment and all dependencies that the workflow will use.
 
+## Expected input
+
+To run this workflow, you will need to provide:
+
+1. Two or more RDS files containing normalized [output `SingleCellExperiment` objects](../README.md#expected-output) from the core dowstream analyses workflow or the processed `SingleCellExperiment` objects downloaded from the ScPCA portal (found in the `_processed.rds` file).
+Each `SingleCellExperiment` object must contain a log-normalized counts matrix in an assay named `logcounts`.
+2. A project metadata tab-separated value (TSV) file containing relevant information about your data necessary for processing, including `sample_id`, `library_id`, `processed_sce_filepath`, and `integration_group` (see more on this in the ["Create metadata file" section](#create-metadata-file) and an example of this metadata file [here](../project-metadata/example-integration-library-metadata.tsv)).
+
+If working with data from the ScPCA portal, see our guide on preparing that data to run the data integration workflow [here](../additional-docs/working-with-scpca-portal-data.md).
+
 ## Create metadata file
 
 Before running the workflow, you must create a project metadata file as a tab-separated value (TSV) file.
@@ -98,3 +108,32 @@ If `--cores` is given without a number, all available cores are used to run the 
 
 You can also modify the config file parameters at the command line, rather than manually as recommended in the configure config file section above.
 See our [command line options](../additional-docs/command-line-options.md) documentation for more information.
+
+## Expected output
+
+For each provided `integration_group`, the workflow will return three files in the `results_dir` specified in the config file:
+
+1. The `_merged_sce.rds` file containing the `SingleCellExperiment` object that results from merging the individual `SingleCellExperiment` objects specified in the project metadata.
+2. The `_integrated_sce.rds` file containing the `SingleCellExperiment` object that has integrated data stored for each `integration_method` as specified in the project metadata.
+2. The `_integration_report.html` file, which is the summary html report with plots containing and comparing the data integration results.
+
+Below is an example of the nested file structure you can expect.
+
+```
+example_results
+├── <integration_group>_integrated_sce.rds
+├── <integration_group>_integration_report.html
+└── <integration_group>_merged_sce.rds
+```
+
+You can also download a ZIP file with an example of the output from running the data integration workflow, including the summary HTML report, processed `SingleCellExperiment` objects stored as RDS files, and the clustering statistics saved as TSV files [here](https://scpca-references.s3.amazonaws.com/example-data/scpca-downstream-analyses/integration_example_results.zip).
+
+### What to expect in the output `SingleCellExperiment` object
+
+In the [`reducedDim`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#dimensionality-reduction-results) of the integrated output `SingleCellExperiment` object, you can find the following:
+
+- Integrated results stored in the reduced dimensions and named using the associated type of integration performed.
+For example, where `fastMNN` is the type of integration performed, the integration results are stored in `fastMNN_PCA` and can be accessed using `reducedDim(sce, "fastMNN_PCA")`.
+
+You can find more information on the above in the [processing information documentation](../additional-docs/processing-information.md).
+

--- a/optional-integration-analysis/README.md
+++ b/optional-integration-analysis/README.md
@@ -10,9 +10,12 @@ The merged objects contain the raw and normalized counts for all included librar
 **Table of Contents**
 
 - [Analysis overview](#analysis-overview)
+- [Expected input](#expected-input)
 - [Create metadata file](#create-metadata-file)
 - [Configure config file](#configure-config-file)
 - [Running the workflow](#running-the-workflow)
+- [Expected output](#expected-output)
+  - [What to expect in the output `SingleCellExperiment` object](#what-to-expect-in-the-output-singlecellexperiment-object)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -90,7 +93,7 @@ To run the workflow on your data, modify the following parameters in the `config
 
 The [`config/integration_config.yaml`](../config/integration_config.yaml) file also contains additional processing parameters like the integration method(s) that should be used and the number of mulit-processing threads to use when merging the data.
 We have set default values for these parameters. 
-Learn more about the [processing parameters](../additional-docs/processing-parameters.md#integration-analysis-parameters) and how to modify them.
+Learn more about the [processing parameters](../additional-docs/additional-parameters.md#integration-analysis-parameters) and how to modify them.
 
 ## Running the workflow
 

--- a/utils/sync-results.sh
+++ b/utils/sync-results.sh
@@ -18,6 +18,7 @@ mkdir -p example-results/sample01
 mkdir -p example-results/sample02
 mkdir -p clustering-example-results/sample01
 mkdir -p clustering-example-results/sample02
+mkdir -p integration-example-results/
 
 # files only found in output from running core worfklow
 core_link_locs=(
@@ -43,6 +44,13 @@ goi_link_locs=(
   sample01/library01_goi_stats
   sample02/library02_goi_report.html
   sample02/library02_goi_stats
+)
+
+# data integration module output files
+integration_link_locs=(
+  group01_integration_report.html
+  group01_integrated_sce.rds
+  group01_merged_sce.rds
 )
 
 for loc in ${core_link_locs[@]}
@@ -78,6 +86,17 @@ do
   fi
 done
 
+for loc in ${integration_link_locs[@]}
+do
+  # only make the links if replacing an old link or the file doesn't exist
+  if [[ -L ${loc} || ! -e ${loc} ]]
+  then
+    ln -nsf ${repo_base}/example-results/${loc} integration-example-results/${loc}
+  else
+    echo "${loc} already exists and is not a link, delete or move it to create a link."
+  fi
+done
+
 # zip and sync core analysis example results
 zip -r core_example_results.zip $repo_base/example-results
 aws s3 cp core_example_results.zip $s3_base/core_example_results.zip --acl public-read
@@ -92,3 +111,8 @@ rm ./clustering_example_results.zip
 zip -r goi_example_results.zip $repo_base/goi-example-results
 aws s3 cp goi_example_results.zip $s3_base/goi_example_results.zip --acl public-read
 rm ./goi_example_results.zip
+
+# zip and sync integration module example results
+zip -r integration_example_results.zip $repo_base/integration-example-results
+aws s3 cp integration_example_results.zip $s3_base/integration_example_results.zip --acl public-read
+rm ./integration_example_results.zip


### PR DESCRIPTION
**Issue Addressed**
Closes #362 and #363

**What is the purpose of these changes?**
<!--Provide some background on the changes proposed.-->
This PR updates the integration module docs with expected input and output sections, as well as the additional parameters docs with the integration parameters.

**What changes did you make?**
<!--Describe the concrete changes that you made or additional features that were added, be as detailed as possible in the steps you took.-->
- Expected input and expected output sections were added to `optional-integration-analysis/README.md`
- An `Integration analysis parameters` section has been added to `additional-docs/additional-parameters.md`
- The `utils/sync-results.sh` script was updated to include the integration results and ran successfully to store the example results on AWS

**Any comments, concerns, or questions important for reviewers**
- Does there appear to be any important information missing from these updates?

**Checklist**

Place an `x` in all boxes that you have completed.

- [ ] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [x] I have added all necessary documentation (if applicable)