### PR TITLE
Jashapiro/env update

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - [Additional analysis modules](#additional-analysis-modules)
   - [Clustering analysis](#clustering-analysis)
   - [Genes of interest analysis](#genes-of-interest-analysis)
+  - [Data integration analysis](#data-integration-analysis)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -45,8 +46,8 @@ Cluster assignments are stored in the `SingleCellExperiment` object returned by 
 
 You can read more details about the individual steps of the workflow in the processing documentation linked below:
 
-|[View Processing Information Documentation](./additional-docs/processing-information.md)|
-|---|
+| [View Processing Information Documentation](./additional-docs/processing-information.md) |
+| ---------------------------------------------------------------------------------------- |
 
 ## Quick Start Guide
 
@@ -64,7 +65,7 @@ The workflow can directly take as input the `filtered` RDS files downloaded from
 snakemake --cores 2 --use-conda
 ```
 
-**Note** that R 4.1 is required for running our pipeline, along with Bioconductor 3.14.
+**Note** that R 4.2 is required for running our pipeline, along with Bioconductor 3.16.
 Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), and `renv` must be installed locally prior to running the workflow.
 If you are using conda, dependencies can be installed as [part of the setup mentioned in step 2 above](#snakemakeconda-installation).
 
@@ -176,8 +177,8 @@ The file should contain the following columns:
 - `filepath`, the full path to the RDS file containing the pre-processed `SingleCellExperiment` object.
 Each library ID should have a unique `filepath`.
 
-|[View Example Metadata File](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/main/example-data/project-metadata/example-library-metadata.tsv)|
-|---|
+| [View Example Metadata File](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/main/example-data/project-metadata/example-library-metadata.tsv) |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 ## 4. Configure config file
 
@@ -186,7 +187,7 @@ Learn more about snakemake configuration files [here](https://snakemake.readthed
 
 The config file contains two sets of parameters:
 
-- **[Project-specific Parameters](./config/config.yaml#L3)**: This set of parameters are for specifying dataset or project related details. 
+- **[Project-specific Parameters](./config/config.yaml#L3)**: This set of parameters are for specifying dataset or project related details.
 These parameters are **required** to run the workflow on your data.
 - **[Processing Parameters](./config/config.yaml#L11)**: This set of parameters specify configurations for the type of filtering to be performed and for cutoffs like the minimum number of genes detected per cell, for example.
 You can change them to explore your data but it is optional.
@@ -195,28 +196,28 @@ You can modify the relevant parameters by manually updating the `config/config.y
 
 To run the workflow on your data, modify the following parameters in the `config/config.yaml` file:
 
-| Parameter        | Description |
-|------------------|-------------|
-| `results_dir` | full path to the directory where output files from running the core workflow will be stored |
-| `project_metadata` | full path to your specific project metadata TSV file |
-| `mito_file` | full path to a file containing a list of mitochondrial genes specific to the reference genome or transcriptome version used for alignment. By default, the workflow will use the mitochondrial gene list obtained from Ensembl version 104 of the Human transcriptome which can be found in the [`reference-files` directory](./reference-files). |
+| Parameter          | Description                                                                                                                                                                                                                                                                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `results_dir`      | full path to the directory where output files from running the core workflow will be stored                                                                                                                                                                                                                                                       |
+| `project_metadata` | full path to your specific project metadata TSV file                                                                                                                                                                                                                                                                                              |
+| `mito_file`        | full path to a file containing a list of mitochondrial genes specific to the reference genome or transcriptome version used for alignment. By default, the workflow will use the mitochondrial gene list obtained from Ensembl version 104 of the Human transcriptome which can be found in the [`reference-files` directory](./reference-files). |
 
-By default, these parameters point to the [example data](./example-data). 
+By default, these parameters point to the [example data](./example-data).
 The two example `_filtered.rds` files were both processed using the [`scpca-nf` workflow](https://github.com/AlexsLemonade/scpca-nf/blob/main/examples/README.md).
 Therefore, if you would like to test this workflow using the example data, you can continue to the next step, running the workflow, without modifying the config file.
 
-The config file also contains additional processing parameters like cutoffs for minimum genes detected, minimum unique molecular identifiers (UMI) per cell, etc. 
-We have set default values for these parameters. 
+The config file also contains additional processing parameters like cutoffs for minimum genes detected, minimum unique molecular identifiers (UMI) per cell, etc.
+We have set default values for these parameters.
 Learn more about the [additional processing parameters](./additional-docs/additional-parameters.md#core-analysis-parameters) and how to modify them.
 
 See the [processing information documentation](./additional-docs/processing-information.md) for more information on the individual workflow steps and how the parameters are used in each of the steps.
 
-|[View Config File](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/main/config/config.yaml)|
-|---|
+| [View Config File](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/main/config/config.yaml) |
+| ----------------------------------------------------------------------------------------------------------- |
 
 ## 5. Running the workflow
 
-After you have successfully modified the required project-specific parameters in the config file, you can run the snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example: 
+After you have successfully modified the required project-specific parameters in the config file, you can run the snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example:
 
 ```
 snakemake --cores 2 --use-conda
@@ -256,27 +257,27 @@ You can also download a ZIP file with an example of the output from running the 
 
 ### What to expect in the output `SingleCellExperiment` object
 
-As a result of the normalization step of the workflow, a log-transformed normalized expression matrix can be accessed using [`logcounts(sce)`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#adding-more-assays).
+As a result of the normalization step of the workflow, a log-transformed normalized expression matrix can be accessed using [`logcounts(sce)`](https://bioconductor.org/books/3.16/OSCA.intro/the-singlecellexperiment-class.html#adding-more-assays).
 
-In the [`colData`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#handling-metadata) of the output `SingleCellExperiment` object, you can find the following:
+In the [`colData`](https://bioconductor.org/books/3.16/OSCA.intro/the-singlecellexperiment-class.html#handling-metadata) of the output `SingleCellExperiment` object, you can find the following:
 
 - Clustering results stored in a metadata column named using the associated clustering type and nearest neighbours values.
 For example, if using the default values of Louvain clustering with a nearest neighbors parameter of 10, the column name would be `louvain_10` and can be accessed using `colData(sce)$louvain_10`.
 
-In the [`metadata`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#other-metadata) of the output `SingleCellExperiment` object, which can be accessed using `metadata(sce)`,  you can find the following information:
+In the [`metadata`](https://bioconductor.org/books/3.16/OSCA.intro/the-singlecellexperiment-class.html#other-metadata) of the output `SingleCellExperiment` object, which can be accessed using `metadata(sce)`,  you can find the following information:
 
-| Metadata Key       | Description |
-|----------------------------|-------------|
-| `scpca_filter_method` | The type of filtering performed ([`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) or `manual`) on the expression data. |
-| `prob_compromised_cutoff` | The maximum probability of cells being compromised, which is only present when the `filtering_method` is set to `miQC`. |
-| `miQC_model` | The linear mixture model calculated by `miQC` and therefore is only present when `filtering_method` is set to `miQC`. |
-| `mito_percent_cutoff` | Maximum percent mitochondrial reads per cell threshold, which is only present when `filtering_method` is set to `manual`. |
-| `genes_filtered` | Indicates whether or not genes have been filtered. |
-| `detected_gene_cutoff` | Minimum number of genes detected per cell, which is only present when `filtering_method` is set to `manual`. |
-| `umi_count_cutoff` | Minimum unique molecular identifiers (UMI) per cell, which is only present when `filtering_method` is set to `manual`. |
-| `num_filtered_cells_retained` | The number of cells retained after filtering using the specified filtering method, either `miQC` or `manual`. |
-| `normalization` | The type of normalization performed (`log-normalization` or `deconvolution` when clustering of similar cells using [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) prior to normalization with `scater::logNormCounts()` is successful). |
-| `highly_variable_genes` | The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html). |
+| Metadata Key                  | Description                                                                                                                                                                                                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scpca_filter_method`         | The type of filtering performed ([`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) or `manual`) on the expression data.                                                                                                                        |
+| `prob_compromised_cutoff`     | The maximum probability of cells being compromised, which is only present when the `filtering_method` is set to `miQC`.                                                                                                                                              |
+| `miQC_model`                  | The linear mixture model calculated by `miQC` and therefore is only present when `filtering_method` is set to `miQC`.                                                                                                                                                |
+| `mito_percent_cutoff`         | Maximum percent mitochondrial reads per cell threshold, which is only present when `filtering_method` is set to `manual`.                                                                                                                                            |
+| `genes_filtered`              | Indicates whether or not genes have been filtered.                                                                                                                                                                                                                   |
+| `detected_gene_cutoff`        | Minimum number of genes detected per cell, which is only present when `filtering_method` is set to `manual`.                                                                                                                                                         |
+| `umi_count_cutoff`            | Minimum unique molecular identifiers (UMI) per cell, which is only present when `filtering_method` is set to `manual`.                                                                                                                                               |
+| `num_filtered_cells_retained` | The number of cells retained after filtering using the specified filtering method, either `miQC` or `manual`.                                                                                                                                                        |
+| `normalization`               | The type of normalization performed (`log-normalization` or `deconvolution` when clustering of similar cells using [`scran::quickCluster()`](https://rdrr.io/bioc/scran/man/quickCluster.html) prior to normalization with `scater::logNormCounts()` is successful). |
+| `highly_variable_genes`       | The subset of the most variable genes, determined using [`scran::getTopHVGs()`](https://rdrr.io/bioc/scran/man/getTopHVGs.html).                                                                                                                                     |
 
 You can find more information on the above in the [processing information documentation](./additional-docs/processing-information.md).
 
@@ -301,6 +302,6 @@ For more on what's in the genes of interest analysis workflow and how to run the
 ### Data integration analysis
 
 There is an optional data integration analysis pipeline in the `optional-integration-analysis` subdirectory of this repository.
-This workflow can can be used to combine data from multiple individual single-cell/single-nuclei libraries to obtain a single integrated object. 
+This workflow can can be used to combine data from multiple individual single-cell/single-nuclei libraries to obtain a single integrated object.
 
 For more on what's in the data integration analysis workflow and how to run the workflow, see the [`README.md`](optional-integration-analysis/README.md) file in the integration analysis subdirectory.

--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ The workflow can directly take as input the `filtered` RDS files downloaded from
 6. Open terminal to run the workflow using the following snakemake command:
 
 ```
-snakemake --cores 2
+snakemake --cores 2 --use-conda
 ```
 
 **Note** that R 4.1 is required for running our pipeline, along with Bioconductor 3.14.
 Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), and `renv` must be installed locally prior to running the workflow.
-These dependencies should be installed as [part of the installation mentioned in step 1](#snakemakeconda-installation).
+If you are using conda, dependencies can be installed as [part of the setup mentioned in step 2 above](#snakemakeconda-installation).
+
+If you did not install dependencies with [conda via snakemake](#snakemakeconda-installation) in step 2, you will need to remove the `--use-conda` flag from the command above.
+See the section on [running the workflow](#4-running-the-workflow) for more information.
 
 **Output Files**
 There are two expected output files thay will be associated with each provided `SingleCellExperiment` object and `library_id`:
@@ -145,8 +148,9 @@ bash setup_envs.sh
 This script will use Snakemake to install all necessary components for the workflow in an isolated environment.
 If you are on an Apple Silicon (M1/M2/Arm) Mac, this should properly handle setting up R to use an Intel-based build for compatibility with Bioconductor packages.
 
-By default, the Snakemake workflows inside this repo will utilize this conda environment. 
-If you have not completed this step, the workflows will not run successfully.
+To use the environment you have just created, you will need to run Snakemake with the `--use-conda` flag each time.
+
+If you would like to perform installation without the conda environments as described above, see the [independent installation instructions document](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/main/additional-docs/independent-installation-instructions.md).
 
 ## 2. Verify input data format
 
@@ -212,14 +216,16 @@ See the [processing information documentation](./additional-docs/processing-info
 
 ## 5. Running the workflow
 
-After you have successfully modified the required project-specific parameters in the config file, you can run the snakemake workflow with just the `--cores` flag as in the following example: 
+After you have successfully modified the required project-specific parameters in the config file, you can run the snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example: 
 
 ```
-snakemake --cores 2
+snakemake --cores 2 --use-conda
 ```
 
 It is mandatory to specify the number of CPU cores for snakemake to use by using the [`--cores` flag](https://snakemake.readthedocs.io/en/stable/tutorial/advanced.html?highlight=cores#step-1-specifying-the-number-of-used-threads).
 If `--cores` is given without a number, all available cores are used to run the workflow.
+
+**Note:** If you did not install dependencies [with conda via snakemake](#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
 
 You can also modify the config file parameters at the command line, rather than manually as recommended in step 4.
 See our [command line options](./additional-docs/command-line-options.md) documentation for more information.

--- a/Snakefile
+++ b/Snakefile
@@ -2,10 +2,6 @@ import pandas as pd
 
 configfile: "config/config.yaml"
 
-# use conda environment
-if 'use-conda' in config and config['use-conda']:
-    workflow.use_conda = True
-
 # getting the samples information
 if os.path.exists(config['project_metadata']):
   samples_information = pd.read_csv(config['project_metadata'], sep='\t', index_col=False)

--- a/additional-docs/command-line-options.md
+++ b/additional-docs/command-line-options.md
@@ -22,6 +22,7 @@ The below code is an example of running the Snakemake workflow using the require
 
 ```
 snakemake --cores 2 \
+  --use-conda \
   --config results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
   project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"
 ```
@@ -40,6 +41,7 @@ The below code is an example of running the additional workflow(s) using the pro
 ```
 snakemake --snakefile <module.snakefile> \ 
   --cores 2 \
+  --use-conda \
   --config input_data_dir="<FULL PATH TO INPUT DATA DIRECTORY>" \
   results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
   project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"

--- a/additional-docs/independent-installation-instructions.md
+++ b/additional-docs/independent-installation-instructions.md
@@ -1,0 +1,48 @@
+# Independent installation instructions
+
+If you would like to perform package and dependency installation without the conda environments as described in the main `README.md` file [here](./README.md##snakemakeconda-installation), you can do so after confirming that you have R version 4.2 installed.
+Then follow the below instructions to ensure that you have all of the necessary R packages to run the workflow installed as well.
+First install the following packages by your preferred method (the package version we used for development is in parentheses):
+
+- `optparse` (1.7.3)
+- `renv` (0.17.0)
+- `rmarkdown` (2.20)
+- `here` (1.0.1)
+- `pandoc` (2.19.2)
+
+Then, from within the `scpca-downstream-analyses` directory, run the following command to install all of the additional required packages:
+
+```
+Rscript -e "renv::restore()"
+```
+
+Note that pandoc must also be installed and in your path to successfully run the `Snakefile`.
+You can install pandoc system-wide by following [pandoc's instructions](https://pandoc.org/installing.html), or you can add it to your conda environment with `mamba install pandoc`.
+
+## Apple Silicon installations
+
+As of Bioconductor 3.16, binary packages of Bioconductor packages are now available for Apple Silicon (M1/M2/Arm) Macs.
+These binary packages should make installation using native code without Snakemake/conda possible, but we have not extensively tested this.
+
+[This link](https://cran.rstudio.com/bin/macosx/big-sur-arm64/base/R-4.2.2-arm64.pkg) will download the Arm64 version of R, version 4.2.2, and you can install R by following the installation instructions.
+
+You may also need to install `gfortan`, a Fortran compiler, to facilitate building certain R packages.
+To do so, follow the instructions at https://mac.r-project.org/tools/ to install the Apple Silicon (arm64) version of `gfortran`.
+Briefly, you will download the latest version of the `gfortran` package, currently at https://mac.r-project.org/tools/gfortran-12.0.1-20220312-is-darwin20-arm64.tar.xz
+After download, unpack the file with:
+
+```
+sudo tar fxz gfortran-12.0.1-20220312-is-darwin20-arm64.tar.xz -C /
+```
+
+After initial installation, update the link to the macOS SDK with:
+
+```
+sudo /opt/R/arm64/gfortran/bin/gfortran-update-sdk`
+```
+
+You will also want to add `/opt/R/arm64/bin` to your `PATH`  by modifying `~/.zshrc` or `~/.bashrc` (depending on your shell) with:
+
+```
+export PATH=$PATH:/opt/R/arm64/gfortran/bin
+```

--- a/additional-docs/working-with-scpca-portal-data.md
+++ b/additional-docs/working-with-scpca-portal-data.md
@@ -30,6 +30,7 @@ The below code is an example of running the Snakemake workflow using the project
 
 ```
 snakemake --cores 2 \
+  --use-conda \
   --config results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
   project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"
 ```
@@ -70,6 +71,7 @@ The below code is an example of running the additional workflow(s) using the pro
 ```
 snakemake --snakefile <module.snakefile> \ 
   --cores 2 \
+  --use-conda \
   --config input_data_dir="<FULL PATH TO INPUT DATA DIRECTORY>" \
   results_dir="<FULL PATH TO RESULTS DIRECTORY>" \
   project_metadata="<FULL PATH TO YOUR PROJECT METADATA TSV>"

--- a/cluster.snakefile
+++ b/cluster.snakefile
@@ -3,10 +3,6 @@ import pandas as pd
 configfile: "config/config.yaml"
 configfile: "config/cluster_config.yaml"
 
-# use conda environment
-if 'use-conda' in config and config['use-conda']:
-    workflow.use_conda = True
-    
 # getting the samples information
 if os.path.exists(config['project_metadata']):
   samples_information = pd.read_csv(config['project_metadata'], sep='\t', index_col=False)

--- a/components/dependencies.R
+++ b/components/dependencies.R
@@ -7,5 +7,6 @@
 #
 # library(dplyr)
 #
-library(uwot)
+library(remotes)
 library(markdown)
+library(uwot)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,9 +14,6 @@ project_metadata: "example-data/project-metadata/example-library-metadata.tsv"
 # Changes to these are not required and can therefore be left at the default values.
 # Although one may want to alter these parameters for exploratory purposes.
 
-# use conda environment -- this parameter is required to run the workflow(s) and should not be modified
-use-conda: TRUE
-
 # seed to use for all steps
 seed: 2021
 

--- a/envs/scpca-renv.post-deploy.sh
+++ b/envs/scpca-renv.post-deploy.sh
@@ -8,9 +8,18 @@ fi
 
 SCPCATOOLS_VERS='main'
 
-# install github packages
+# install packages not on conda-forge
 Rscript --vanilla -e \
   "
+  # install Harmony from CRAN
+  remotes::install_version(
+    'harmony', 
+    version = '0.1.1', 
+    repos = 'https://cloud.r-project.org', 
+    upgrade = FALSE
+  )
+
+  # install ScPCA tools from Github
   remotes::install_github('AlexsLemonade/scpcaTools', ref='${SCPCATOOLS_VERS}', upgrade='never')
   require(scpcaTools) # check installation
   "

--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -61,7 +61,7 @@ dependencies:
   - r-beeswarm=0.4.0
   - r-bh=1.81.0_1
   - r-bigd=0.2.0
-  - r-biocmanager=1.30.20
+  - r-biocmanager=1.30.22
   - r-bit=4.0.5
   - r-bit64=4.0.5
   - r-bitops=1.0_7

--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -51,6 +51,7 @@ dependencies:
   - bioconductor-tximport=1.26.0
   - bioconductor-xvector=0.38.0
   - bioconductor-zlibbioc=1.44.0
+  - conda-ecosystem-user-package-isolation=1.0
   - pandoc=2.19.2
   - r-abind=1.4_5
   - r-askpass=1.1
@@ -324,5 +325,4 @@ dependencies:
   - r-yaml=2.3.7
   - r-zip=2.2.2
 variables:
-  R_LIBS_USER: null
   RENV_PROJECT: null

--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -36,6 +36,7 @@ dependencies:
   - bioconductor-org.hs.eg.db=3.16.0
   - bioconductor-org.mm.eg.db=3.16.0
   - bioconductor-qvalue=2.30.0
+  - bioconductor-residualmatrix=1.8.0
   - bioconductor-rhdf5=2.42.0
   - bioconductor-rhdf5filters=1.10.0
   - bioconductor-rhdf5lib=1.20.0
@@ -55,10 +56,11 @@ dependencies:
   - r-askpass=1.1
   - r-assertthat=0.2.1
   - r-backports=1.4.1
-  - r-base=4.2.2
+  - r-base=4.2.3
   - r-base64enc=0.1_3
   - r-beeswarm=0.4.0
   - r-bh=1.81.0_1
+  - r-bigd=0.2.0
   - r-biocmanager=1.30.20
   - r-bit=4.0.5
   - r-bit64=4.0.5
@@ -122,10 +124,10 @@ dependencies:
   - r-future=1.31.0
   - r-future.apply=1.10.0
   - r-generics=0.1.3
+  - r-geometry=0.4.7
   - r-gert=1.9.2
   - r-getopt=1.20.3
   - r-getoptlong=1.0.5
-  - r-geometry=0.4.7
   - r-ggbeeswarm=0.7.1
   - r-ggforce=0.4.1
   - r-ggplot2=3.4.1
@@ -142,6 +144,7 @@ dependencies:
   - r-gower=1.0.1
   - r-gridextra=2.3
   - r-grr=0.9.5
+  - r-gt=0.9.0
   - r-gtable=0.3.1
   - r-gtools=3.9.4
   - r-hardhat=1.2.0
@@ -162,6 +165,7 @@ dependencies:
   - r-iterators=1.0.14
   - r-jquerylib=0.1.4
   - r-jsonlite=1.8.4
+  - r-juicyjuice=0.1.0
   - r-kableextra=1.3.4
   - r-kernsmooth=2.23_20
   - r-knitr=1.42
@@ -208,7 +212,7 @@ dependencies:
   - r-pkgbuild=1.4.0
   - r-pkgconfig=2.0.3
   - r-pkgdown=2.0.7
-  - r-pkgload=1.3.2
+  - r-pkgload=1.3.2.1
   - r-plogr=0.2.0
   - r-plyr=1.8.8
   - r-png=0.1_8
@@ -244,13 +248,15 @@ dependencies:
   - r-rcppparallel=5.1.6
   - r-rcppprogress=0.4.2
   - r-rcurl=1.98_1.10
+  - r-reactable=0.4.4
+  - r-reactr=0.4.4
   - r-readr=2.1.4
   - r-readxl=1.4.2
   - r-recipes=1.0.5
   - r-rematch=1.0.1
   - r-rematch2=2.1.2
-  - r-remotes=2.4.2
-  - r-renv=0.17.0
+  - r-remotes=2.4.2.1
+  - r-renv=1.0.0
   - r-reshape2=1.4.4
   - r-rio=0.5.29
   - r-rjson=0.2.21
@@ -272,7 +278,7 @@ dependencies:
   - r-selectr=0.4_2
   - r-sessioninfo=1.2.2
   - r-shape=1.4.6
-  - r-shiny=1.7.4
+  - r-shiny=1.7.4.1
   - r-sitmo=2.0.2
   - r-snow=0.4_4
   - r-sourcetools=0.1.7_1
@@ -301,6 +307,7 @@ dependencies:
   - r-usethis=2.1.6
   - r-utf8=1.2.3
   - r-uwot=0.1.14
+  - r-v8=4.3.3
   - r-vctrs=0.5.2
   - r-vipor=0.4.5
   - r-viridis=0.6.2

--- a/goi.snakefile
+++ b/goi.snakefile
@@ -3,10 +3,6 @@ import pandas as pd
 configfile: "config/config.yaml"
 configfile: "config/goi_config.yaml"
 
-# use conda environment
-if 'use-conda' in config and config['use-conda']:
-    workflow.use_conda = True
-    
 # getting the samples information
 if os.path.exists(config['project_metadata']):
   samples_information = pd.read_csv(config['project_metadata'], sep='\t', index_col=False)

--- a/integration.snakefile
+++ b/integration.snakefile
@@ -3,10 +3,6 @@ import pandas as pd
 configfile: "config/config.yaml"
 configfile: "config/integration_config.yaml"
 
-# use conda environment
-if 'use-conda' in config and config['use-conda']:
-    workflow.use_conda = True
-    
 # getting the samples information
 if os.path.exists(config['integration_project_metadata']):
   samples_information = pd.read_csv(config['integration_project_metadata'], sep='\t', index_col=False)

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -1,6 +1,6 @@
 # Optional Clustering Analysis
 
-This directory includes a clustering analysis workflow that can help users identify the optimal clustering method and parameters for each library in their dataset. 
+This directory includes a clustering analysis workflow that can help users identify the optimal clustering method and parameters for each library in their dataset.
 
 **The clustering analysis workflow cannot be implemented until after users have successfully run the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file or have downloaded data from the [ScPCA portal](https://scpca.alexslemonade.org/).**
 
@@ -39,7 +39,7 @@ Additionally, metrics associated with each of the clustering results such as sil
 The plots are displayed in a html report for ease of reference.
 
 **Note** that the same [software requirements for the core workflow](../README.md#3-additional-dependencies) are also required for this clustering workflow.
-R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
+R 4.2 is required for running our pipeline, along with Bioconductor 3.16.
 Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which must be installed locally prior to running the workflow.
 If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
 
@@ -61,7 +61,7 @@ Learn more about snakemake configuration files [here](https://snakemake.readthed
 
 The config file contains two sets of parameters:
 
-- **[Project-specific Parameters](../config/config.yaml#L3)**: This set of parameters are for specifying dataset or project related details. 
+- **[Project-specific Parameters](../config/config.yaml#L3)**: This set of parameters are for specifying dataset or project related details.
 These parameters are **required** to run the workflow on your data.
 - **[Processing Parameters](../config/cluster_config.yaml)**: This set of parameters specify configurations for the type(s) of graph-based clustering to be performed, as well as the range of nearest neighbors values to use.
 You can change them to explore your data but it is optional.
@@ -69,24 +69,24 @@ You can modify the relevant parameters by manually updating the `config/cluster_
 
 To run the workflow on your data, modify the following parameters in the `config/config.yaml` file:
 
-| Parameter        | Description |
-|------------------|-------------|
-| `input_data_dir` | full path to the directory where the input data files can be found (default will be the `results_dir` used in the core workflow) |
-| `results_dir` | full path to the directory where output files will be stored |
-| `project_metadata` | full path to your specific project metadata TSV file (use the same `project_metadata` used in the prerequisite core workflow) |
+| Parameter          | Description                                                                                                                      |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `input_data_dir`   | full path to the directory where the input data files can be found (default will be the `results_dir` used in the core workflow) |
+| `results_dir`      | full path to the directory where output files will be stored                                                                     |
+| `project_metadata` | full path to your specific project metadata TSV file (use the same `project_metadata` used in the prerequisite core workflow)    |
 
-|[View Config File](../config/config.yaml)|
-|---|
+| [View Config File](../config/config.yaml) |
+| ----------------------------------------- |
 
 The [`config/cluster_config.yaml`](../config/cluster_config.yaml) file also contains additional processing parameters like the type of graph-based clustering to be performed and the nearest neighbors values that should be used.
-We have set default values for these parameters. 
+We have set default values for these parameters.
 Learn more about the [processing parameters](../additional-docs/processing-parameters.md#clustering-analysis-parameters) and how to modify them.
 
 ## Running the workflow
 
 The execution file with the clustering Snakemake workflow is named `cluster.snakefile` and can be found in the root directory. To tell snakemake to run the specific clustering workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `cluster.snakefile`.
 
-After you have successfully modified the required project-specific parameters in the config file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example: 
+After you have successfully modified the required project-specific parameters in the config file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example:
 
 ```
 snakemake --snakefile cluster.snakefile --cores 2 --use-conda
@@ -127,7 +127,7 @@ You can also download a ZIP file with an example of the output from running the 
 
 ### What to expect in the output `SingleCellExperiment` object
 
-In the [`colData`](https://bioconductor.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#handling-metadata) of the output `SingleCellExperiment` object, you can find the following:
+In the [`colData`](https://.org/books/3.13/OSCA.intro/the-singlecellexperiment-class.html#handling-metadata) of the output `SingleCellExperiment` object, you can find the following:
 
 - Clustering results stored in a metadata column named using the associated clustering type and nearest neighbours values.
 For example, where `n` is a value within a range of nearest neighbors values provided to perform Louvain clustering, the column name would be `louvain_n` and can be accessed using `colData(sce)$louvain_n`.

--- a/optional-clustering-analysis/README.md
+++ b/optional-clustering-analysis/README.md
@@ -38,10 +38,10 @@ Cluster validity and stability results are also calculated.
 Additionally, metrics associated with each of the clustering results such as silhouette width, cluster purity, and cluster stability (as described above) are calculated and plotted.
 The plots are displayed in a html report for ease of reference.
 
-**Note** that the same [software requirements for the core workflow](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/cbethell/make-conda-default/README.md#c-additional-dependencies) are also required for this clustering workflow. 
-R 4.2 is required for running our pipeline, along with Bioconductor 3.15. If you are using conda, dependencies can be installed as [part of the initial setup](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/cbethell/make-conda-default/README.md#snakemakeconda-installation). 
-Package dependencies for the analysis workflows in this repository are managed using [renv](https://rstudio.github.io/renv/index.html), which can be installed independently if desired. 
-Still, we recommend using Snakemake's conda integration to set up the R environment and all dependencies that the workflow will use.
+**Note** that the same [software requirements for the core workflow](../README.md#3-additional-dependencies) are also required for this clustering workflow.
+R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
+Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which must be installed locally prior to running the workflow.
+If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
 
 ## Expected input
 
@@ -86,14 +86,16 @@ Learn more about the [processing parameters](../additional-docs/processing-param
 
 The execution file with the clustering Snakemake workflow is named `cluster.snakefile` and can be found in the root directory. To tell snakemake to run the specific clustering workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `cluster.snakefile`.
 
-After you have successfully modified the required project-specific parameters in the config file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` flag as in the following example: 
+After you have successfully modified the required project-specific parameters in the config file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example: 
 
 ```
-snakemake --snakefile cluster.snakefile --cores 2
+snakemake --snakefile cluster.snakefile --cores 2 --use-conda
 ```
 
 It is mandatory to specify the number of CPU cores for snakemake to use by using the [`--cores` flag](https://snakemake.readthedocs.io/en/stable/tutorial/advanced.html?highlight=cores#step-1-specifying-the-number-of-used-threads).
 If `--cores` is given without a number, all available cores are used to run the workflow.
+
+**Note:** If you did not install dependencies [with conda via snakemake](#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
 
 You can also modify the config file parameters at the command line, rather than manually as recommended in the configure config file section above.
 See our [command line options](../additional-docs/command-line-options.md) documentation for more information.

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -31,10 +31,10 @@ The normalized and transformed expression for each of the provided genes of inte
 UMAP and PCA plots are also provided, where each dot represents a cell and the color indicates the individual gene of interest’s expression.
 
 
-**Note** that the same [software requirements for the core workflow](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/cbethell/make-conda-default/README.md#c-additional-dependencies) are also required for this clustering workflow. 
-R 4.2 is required for running our pipeline, along with Bioconductor 3.15. If you are using conda, dependencies can be installed as [part of the initial setup](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/cbethell/make-conda-default/README.md#snakemakeconda-installation). 
-Package dependencies for the analysis workflows in this repository are managed using [renv](https://rstudio.github.io/renv/index.html), which can be installed independently if desired. 
-Still, we recommend using Snakemake's conda integration to set up the R environment and all dependencies that the workflow will use.
+**Note** that the same [software requirements for the core workflow](../README.md#3-additional-dependencies) are also required for this clustering workflow.
+R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
+Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which must be installed locally prior to running the workflow.
+If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
 
 ## Expected input
 
@@ -90,14 +90,16 @@ Learn more about the [gene mapping parameters](../additional-docs/additional-par
 The execution file with the genes of interest Snakemake workflow is named `goi.snakefile` and can be found in the root directory.
 To tell snakemake to run the specific genes of interest workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `goi.snakefile`.
 
-After you have successfully modified the required project-specific parameters in the config file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` flag as in the following example: 
+After you have successfully modified the required project-specific parameters in the config file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example: 
 
 ```
-snakemake --snakefile goi.snakefile --cores 2
+snakemake --snakefile goi.snakefile --cores 2 --use-conda
 ```
 
 It is mandatory to specify the number of CPU cores for snakemake to use by using the [`--cores` flag](https://snakemake.readthedocs.io/en/stable/tutorial/advanced.html?highlight=cores#step-1-specifying-the-number-of-used-threads).
 If `--cores` is given without a number, all available cores are used to run the workflow.
+
+**Note:** If you did not install dependencies [with conda via snakemake](#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
 
 You can also modify the config file parameters at the command line, rather than manually as recommended in the configure config file section above.
 See our [command line options](../additional-docs/command-line-options.md) documentation for more information.

--- a/optional-goi-analysis/README.md
+++ b/optional-goi-analysis/README.md
@@ -32,7 +32,7 @@ UMAP and PCA plots are also provided, where each dot represents a cell and the c
 
 
 **Note** that the same [software requirements for the core workflow](../README.md#3-additional-dependencies) are also required for this clustering workflow.
-R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
+R 4.2 is required for running our pipeline, along with Bioconductor 3.16.
 Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which must be installed locally prior to running the workflow.
 If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
 
@@ -55,7 +55,7 @@ Learn more about snakemake configuration files [here](https://snakemake.readthed
 
 The config file contains two sets of parameters:
 
-- **[Project-specific Parameters](../config/config.yaml#L3)**: This set of parameters are for specifying dataset or project related details. 
+- **[Project-specific Parameters](../config/config.yaml#L3)**: This set of parameters are for specifying dataset or project related details.
 These parameters are **required** to run the workflow on your data.
 - **[Processing Parameters](../config/goi_config.yaml)**: This set of parameters specify configurations for how to handle multiple gene identifier mappings, for example.
 You can change them to explore your data but it is optional.
@@ -63,26 +63,26 @@ You can modify the relevant parameters by manually updating the `config/goi_conf
 
 To run the workflow on your data, modify the following parameters in the `config/config.yaml` and `config/goi_config.yaml` files:
 
-| Parameter        | Description | Default value |
-|------------------|-------------| --------------|
-| `input_data_dir` | full path to the directory where the input data files can be found (default will be the `results_dir` used in the core workflow) | `"example_results"` |
-| `results_dir` | full path to the directory where output files will be stored | `"example-results"` |
-| `project_metadata` | full path to your specific project metadata TSV file (use the same `project_metadata` used in the prerequisite core workflow) | `"example-data/project-metadata/example-library-metadata.tsv"` |
-| `goi_list` | full path to a tsv file containing the list of genes that are of interest | `"example-data/goi-lists/example_goi_list.tsv"` |
-| `provided_identifier` | the type of gene identifiers used to populate the genes of interest list; example values that can implemented here include `"ENSEMBL"`, `"ENTREZID"`, `"SYMBOL"`; see more keytypes [here](https://jorainer.github.io/ensembldb/reference/EnsDb-AnnotationDbi.html) | `"SYMBOL"` |
-| `overwrite` | a binary value indicating whether or not to overwrite existing output files | `TRUE` |
+| Parameter             | Description                                                                                                                                                                                                                                                         | Default value                                                  |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `input_data_dir`      | full path to the directory where the input data files can be found (default will be the `results_dir` used in the core workflow)                                                                                                                                    | `"example_results"`                                            |
+| `results_dir`         | full path to the directory where output files will be stored                                                                                                                                                                                                        | `"example-results"`                                            |
+| `project_metadata`    | full path to your specific project metadata TSV file (use the same `project_metadata` used in the prerequisite core workflow)                                                                                                                                       | `"example-data/project-metadata/example-library-metadata.tsv"` |
+| `goi_list`            | full path to a tsv file containing the list of genes that are of interest                                                                                                                                                                                           | `"example-data/goi-lists/example_goi_list.tsv"`                |
+| `provided_identifier` | the type of gene identifiers used to populate the genes of interest list; example values that can implemented here include `"ENSEMBL"`, `"ENTREZID"`, `"SYMBOL"`; see more keytypes [here](https://jorainer.github.io/ensembldb/reference/EnsDb-AnnotationDbi.html) | `"SYMBOL"`                                                     |
+| `overwrite`           | a binary value indicating whether or not to overwrite existing output files                                                                                                                                                                                         | `TRUE`                                                         |
 
 ## Gene mapping
 
-The first step in the workflow is to ensure that the input gene identifiers provided in the genes of interest list match the gene identifiers present in the `SingleCellExperiment` object. 
+The first step in the workflow is to ensure that the input gene identifiers provided in the genes of interest list match the gene identifiers present in the `SingleCellExperiment` object.
 The `SingleCellExperiment` objects that are returned by the core workflow will contain gene names as Ensembl ids.
 If the provided genes of interest list contains another identifier type (e.g., gene symbol, Entrez id) that does not match the gene names present in the `SingleCellExperiment` objects, then mapping must be performed.
 The `perform_mapping` flag is used to indicate whether or not gene mapping will be performed and by default is set to `TRUE`.
 
 To run the workflow without the gene mapping step, you will need to modify the `perform_mapping` parameter to be `FALSE` in the `config/goi_config.yaml` file.
 
-The `config/goi_config.yaml` file also contains additional processing parameters like how to handle multiple gene identifier mappings. 
-We have set default values for these parameters. 
+The `config/goi_config.yaml` file also contains additional processing parameters like how to handle multiple gene identifier mappings.
+We have set default values for these parameters.
 Learn more about the [gene mapping parameters](../additional-docs/additional-parameters.md#genes-of-interest-analysis-parameters) and how to modify them.
 
 ## Running the workflow
@@ -90,7 +90,7 @@ Learn more about the [gene mapping parameters](../additional-docs/additional-par
 The execution file with the genes of interest Snakemake workflow is named `goi.snakefile` and can be found in the root directory.
 To tell snakemake to run the specific genes of interest workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `goi.snakefile`.
 
-After you have successfully modified the required project-specific parameters in the config file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example: 
+After you have successfully modified the required project-specific parameters in the config file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example:
 
 ```
 snakemake --snakefile goi.snakefile --cores 2 --use-conda

--- a/optional-integration-analysis/README.md
+++ b/optional-integration-analysis/README.md
@@ -1,6 +1,6 @@
 # Optional Integration Analysis
 
-This directory includes a data integration workflow that can be used to combine data from multiple individual single-cell/single-nuclei libraries to obtain a single merged object. 
+This directory includes a data integration workflow that can be used to combine data from multiple individual single-cell/single-nuclei libraries to obtain a single merged object.
 The merged objects contain the raw and normalized counts for all included libraries as well as batch corrected PCA and UMAP results.
 
 **The data integration workflow cannot be implemented until after users have successfully run the main downstream analysis core workflow as described in this repository's main [README.md](../README.md) file or have downloaded data from the [ScPCA portal](https://scpca.alexslemonade.org/).**
@@ -41,7 +41,7 @@ The metrics we use to evaluate integration, as mentioned in step 3 above, includ
 - Within-batch ARI, which measures how well a given integration method preserves biological heterogeneity by comparing pre- and post-integration clustering assignments for each library.
 
 **Note** that the same [software requirements for the core workflow](../README.md#3-additional-dependencies) are also required for this clustering workflow.
-R 4.2 is required for running our pipeline, along with Bioconductor 3.15.
+R 4.2 is required for running our pipeline, along with Bioconductor 3.16.
 If you are using conda, dependencies can be installed as [part of the initial setup](../README.md#snakemakeconda-installation).
 Package dependencies for the analysis workflows in this repository are managed using [`renv`](https://rstudio.github.io/renv/index.html), which can be installed independently if desired, but we recommend using Snakemake's conda integration to set up the R environment and all dependencies that the workflow will use.
 
@@ -62,15 +62,15 @@ Before running the workflow, you must create a project metadata file as a tab-se
 Each row in the metadata should correspond to a single-cell/single-nuclei library to include in integration.
 The file should contain the following columns:
 
-| column name | description |
-| ----------- | ----------- |
-| `sample_id` | Unique ID for each piece of tissue or sample that cells were obtained from,  all libraries that were sampled from the same piece of tissue should have the same `sample_id`. |
-| `library_id` | Unique ID used for each set of cells that has been prepped and sequenced separately. |
+| column name              | description                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sample_id`              | Unique ID for each piece of tissue or sample that cells were obtained from,  all libraries that were sampled from the same piece of tissue should have the same `sample_id`.                                                                                                                                                                                                                                                                                        |
+| `library_id`             | Unique ID used for each set of cells that has been prepped and sequenced separately.                                                                                                                                                                                                                                                                                                                                                                                |
 | `processed_sce_filepath` | The full path to the RDS file containing the processed `SingleCellExperiment` object, each library ID should have a unique `processed_sce_filepath`; note that this RDS file is the output RDS file from the [core analysis workflow](../README.md#6-expected-output) OR the processed file from the [Single-cell Pediatric Cancer Atlas portal](https://scpca.alexslemonade.org/). The filename should contain the following format, `<library_id>_processed.rds`. |
-| `integration_group` | Name used to specify which libraries should be merged. All libraries with the same `integration_group` will be merged and integrated into a single `SingleCellExperiment` object. |
+| `integration_group`      | Name used to specify which libraries should be merged. All libraries with the same `integration_group` will be merged and integrated into a single `SingleCellExperiment` object.                                                                                                                                                                                                                                                                                   |
 
-|[View Example Metadata File](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/main/example-data/project-metadata/example-integration-library-metadata.tsv)|
-|---|
+| [View Example Metadata File](https://github.com/AlexsLemonade/scpca-downstream-analyses/blob/main/example-data/project-metadata/example-integration-library-metadata.tsv) |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 
 ## Configure config file
@@ -80,7 +80,7 @@ Learn more about snakemake configuration files [here](https://snakemake.readthed
 
 The config file contains two sets of parameters:
 
-- **[Project-specific Parameters](../config/integration_config.yaml#L3)**: This set of parameters are for specifying dataset or project related details. 
+- **[Project-specific Parameters](../config/integration_config.yaml#L3)**: This set of parameters are for specifying dataset or project related details.
 These parameters are **required** to run the workflow on your data.
 - **[Processing Parameters](../config/integration_config.yaml#L7)**: This set of parameters specify configurations for the integration method(s) to be performed.
 You can change them to explore your data but it is optional.
@@ -88,24 +88,24 @@ You can modify the relevant parameters by manually updating the `config/integrat
 
 To run the workflow on your data, modify the following parameters in the `config/integration_config.yaml` file:
 
-| Parameter        | Description |
-|------------------|-------------|
-| `results_dir` | full path to the directory where output files will be stored |
+| Parameter                      | Description                                                      |
+| ------------------------------ | ---------------------------------------------------------------- |
+| `results_dir`                  | full path to the directory where output files will be stored     |
 | `integration_project_metadata` | full path to your integration-specific project metadata TSV file |
 
-|[View Integration Config File](../config/integration_config.yaml)|
-|---|
+| [View Integration Config File](../config/integration_config.yaml) |
+| ----------------------------------------------------------------- |
 
 The [`config/integration_config.yaml`](../config/integration_config.yaml) file also contains additional processing parameters like the integration method(s) that should be used and the number of mulit-processing threads to use when merging the data.
-We have set default values for these parameters. 
+We have set default values for these parameters.
 Learn more about the [processing parameters](../additional-docs/additional-parameters.md#integration-analysis-parameters) and how to modify them.
 
 ## Running the workflow
 
-The execution file with the data integration Snakemake workflow is named `integration.snakefile` and can be found in the root directory. 
+The execution file with the data integration Snakemake workflow is named `integration.snakefile` and can be found in the root directory.
 To tell snakemake to run the specific clustering workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `integration.snakefile`.
 
-After you have successfully modified the required project-specific parameters in the `integration_config.yaml` file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example:  
+After you have successfully modified the required project-specific parameters in the `integration_config.yaml` file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example:
 
 ```
 snakemake --snakefile integration.snakefile --cores 2 --use-conda

--- a/optional-integration-analysis/README.md
+++ b/optional-integration-analysis/README.md
@@ -105,14 +105,16 @@ Learn more about the [processing parameters](../additional-docs/additional-param
 The execution file with the data integration Snakemake workflow is named `integration.snakefile` and can be found in the root directory. 
 To tell snakemake to run the specific clustering workflow be sure to use the `--snakefile` or `-s` option followed by the name of the snakefile, `integration.snakefile`.
 
-After you have successfully modified the required project-specific parameters in the `integration_config.yaml` file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` flag as in the following example:  
+After you have successfully modified the required project-specific parameters in the `integration_config.yaml` file and navigated to within the root directory of the `scpca-downstream-analyses` repository, you can run the clustering Snakemake workflow with just the `--cores` and `--use-conda` flags as in the following example:  
 
 ```
-snakemake --snakefile integration.snakefile --cores 2
+snakemake --snakefile integration.snakefile --cores 2 --use-conda
 ```
 
 It is mandatory to specify the number of CPU cores for snakemake to use by using the [`--cores` flag](https://snakemake.readthedocs.io/en/stable/tutorial/advanced.html?highlight=cores#step-1-specifying-the-number-of-used-threads).
 If `--cores` is given without a number, all available cores are used to run the workflow.
+
+**Note:** If you did not install dependencies [with conda via snakemake](#snakemakeconda-installation), you will need to remove the `--use-conda` flag.
 
 You can also modify the config file parameters at the command line, rather than manually as recommended in the configure config file section above.
 See our [command line options](../additional-docs/command-line-options.md) documentation for more information.

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -13,14 +13,14 @@ params:
 title: "`r glue::glue('Integration analysis report for {params$integration_group}')`"
 author: "CCDL"
 date: "`r params$date`"
-output: 
+output:
   html_document:
     toc: true
     toc_depth: 2
     toc_float: true
     number_sections: true
     code_folding: hide
-editor_options: 
+editor_options:
   chunk_output_type: console
 ---
 
@@ -34,12 +34,12 @@ knitr::opts_chunk$set(
   warning = FALSE
 )
 
-# If project root is not provided use here::here() 
+# If project root is not provided use here::here()
 if (is.null(params$project_root)) {
   project_root <- here::here()
 } else {
   project_root <- params$project_root
-} 
+}
 
 # Tell knitr to knit from the project root to be able to load `renv` properly
 # This path goes into effect for SUBSEQUENT chunks, hence the need for 2 chunks
@@ -48,11 +48,6 @@ knitr::opts_knit$set(root.dir = project_root)
 # Source in set up function
 source(file.path(project_root, "utils", "setup-functions.R"))
 source(file.path(project_root, "utils", "integration-functions.R"))
-
-# Install `gt` package
-if(!("gt" %in% installed.packages())){
-  install.packages("gt", repos = "http://cran.us.r-project.org")
-}
 ```
 
 ```{r, include = FALSE}
@@ -84,7 +79,7 @@ integrated_sce <- readr::read_rds(params$integrated_sce)
 ```{r results='asis'}
 # pull out an SCE object for this section
 # all SCEs in the list should be equivalent for these calculations and plots
-sce_coldata <- colData(integrated_sce) |> 
+sce_coldata <- colData(integrated_sce) |>
   tibble::as_tibble()
 
 # How many batches?
@@ -125,12 +120,12 @@ batch_umaps <- integration_methods |>
                                      legend_labels = batch_plot_labels,
                                      seed = params$seed))
 batch_legend <- cowplot::get_legend(batch_umaps[[1]])
-  
+
 ggpubr::ggarrange(plotlist = batch_umaps,
-                  common.legend = TRUE, 
+                  common.legend = TRUE,
                   legend = "right",
-                  ncol = 2, 
-                  nrow = 2) 
+                  ncol = 2,
+                  nrow = 2)
 ```
 
 ## Batch ASW plots
@@ -177,7 +172,7 @@ Within-batch ARI values close to 1 indicate that biological heterogeneity has be
 
 ```{r}
 # List of SCE filepaths
-input_metadata <- readr::read_tsv(params$input_metadata_tsv) |> 
+input_metadata <- readr::read_tsv(params$input_metadata_tsv) |>
   dplyr::filter(integration_group == params$integration_group)
 sce_files <- input_metadata |>
   dplyr::pull(processed_sce_filepath)
@@ -197,7 +192,7 @@ within_batch_ari_df <-
     seed = params$seed
  ) |>
   dplyr::mutate(ari = as.numeric(ari))
-                                                  
+
 ```
 
 ```{r}

--- a/optional-integration-analysis/merge-sce.R
+++ b/optional-integration-analysis/merge-sce.R
@@ -5,8 +5,7 @@
 
 # Load libraries
 library(optparse)
-library(dplyr)
-library(SingleCellExperiment)
+
 
 # Declare command line options
 option_list <- list(
@@ -65,6 +64,9 @@ check_r_version()
 # Set up renv
 setup_renv(project_filepath = project_root)
 
+# Load additional library
+library(SingleCellExperiment)
+
 # Check that file extension for output file is correct
 if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
   stop("output file name must end in .rds")
@@ -90,7 +92,7 @@ if(is.null(opt$integration_group)) {
 }
 
 # List of SCE filepaths
-sce_files <- input_metadata$processed_sce_filepath |> 
+sce_files <- input_metadata$processed_sce_filepath |>
   purrr::set_names(input_metadata$library_id)
 
 # Check that input files exist

--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -3,15 +3,8 @@
 
 ## Set up ----------------------------------------------------------------------
 
-if (!("harmony" %in% installed.packages())) {
-  remotes::install_version("harmony", version = "0.1.1")
-}
-
-# Load libraries
+# Load optparse
 library(optparse)
-library(dplyr)
-library(SingleCellExperiment)
-library(scpcaTools)
 
 # Declare command line options
 option_list <- list(
@@ -24,7 +17,7 @@ option_list <- list(
     opt_str = c("--integration_method"),
     type = "character",
     default = "fastMNN,harmony",
-    help = "The integration method(s) to use when performing integration; 
+    help = "The integration method(s) to use when performing integration;
     default is 'fastMNN,harmony'"
   ),
   make_option(
@@ -74,6 +67,10 @@ check_r_version()
 # Set up renv
 setup_renv(project_filepath = project_root)
 
+# Load additional libraries
+library(SingleCellExperiment)
+library(scpcaTools)
+
 # Check that file extension for output file is correct
 if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
   stop("output file name must end in .rds")
@@ -102,7 +99,7 @@ if (!all(integration_methods %in% c("fastMNN", "harmony"))) {
 
 # Check that `library_id` is in merged SCE object
 if(!("library_id" %in% colnames(colData(merged_sce)))){
-  stop("The 'library_id' column is missing from the `colData` of the merged SCE 
+  stop("The 'library_id' column is missing from the `colData` of the merged SCE
        object and is needed for integration.")
 }
 
@@ -115,8 +112,8 @@ if ("fastMNN" %in% integration_methods) {
         unlist() |>
         stringr::str_trim()
       if(!all(colData(merged_sce)$library_id %in% fastmnn_merge_order)){
-        stop("The provided library ids do not match those in the SCE object. 
-             Please re-run and provide --fastmnn_merge_order with all library ids 
+        stop("The provided library ids do not match those in the SCE object.
+             Please re-run and provide --fastmnn_merge_order with all library ids
              found in the `colData` of the SCE object.")
       }
     }
@@ -128,18 +125,18 @@ if ("fastMNN" %in% integration_methods) {
                                    batch_column = "library_id",
                                    auto.merge = opt$fastmnn_auto_merge,
                                    merge.order = fastmnn_merge_order)
-  
+
   merged_sce <- add_integrated_pcs(merged_sce,
                                    integrated_pcs = reducedDim(fastMNN_integrated_sce, "fastMNN_PCA"),
                                    integration_method = "fastMNN")
-  
+
 }
 
 if ("harmony" %in% integration_methods) {
   harmony_integrated_sce <- integrate_sces(merged_sce,
                                    integration_method = "harmony",
                                    batch_column = "library_id")
-  
+
   merged_sce <- add_integrated_pcs(merged_sce,
                                    integrated_pcs = reducedDim(harmony_integrated_sce, "harmony_PCA"),
                                    integration_method = "harmony")

--- a/renv.lock
+++ b/renv.lock
@@ -3,28 +3,8 @@
     "Version": "4.2.3",
     "Repositories": [
       {
-        "Name": "BioCsoft",
-        "URL": "https://bioconductor.org/packages/3.16/bioc"
-      },
-      {
-        "Name": "BioCann",
-        "URL": "https://bioconductor.org/packages/3.16/data/annotation"
-      },
-      {
-        "Name": "BioCexp",
-        "URL": "https://bioconductor.org/packages/3.16/data/experiment"
-      },
-      {
-        "Name": "BioCworkflows",
-        "URL": "https://bioconductor.org/packages/3.16/workflows"
-      },
-      {
-        "Name": "BioCbooks",
-        "URL": "https://bioconductor.org/packages/3.16/books"
-      },
-      {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       }
     ]
   },
@@ -86,13 +66,13 @@
     },
     "BiocManager": {
       "Package": "BiocManager",
-      "Version": "1.30.20",
+      "Version": "1.30.22",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "a7fca16a50b6ef7771b49d636dd54b57"
+      "Hash": "d57e43105a1aa9cb54fdb4629725acb1"
     },
     "BiocNeighbors": {
       "Package": "BiocNeighbors",

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.2.2",
+    "Version": "4.2.3",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -16,10 +16,6 @@
       "Package": "AnnotationDbi",
       "Version": "1.60.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/AnnotationDbi",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "cd61bd1",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "Biobase",
         "BiocGenerics",
@@ -47,10 +43,6 @@
       "Package": "Biobase",
       "Version": "2.58.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/Biobase",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "767f2f3",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -63,10 +55,6 @@
       "Package": "BiocGenerics",
       "Version": "0.44.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/BiocGenerics",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "d7cd9c1",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "R",
         "graphics",
@@ -90,10 +78,6 @@
       "Package": "BiocNeighbors",
       "Version": "1.16.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/BiocNeighbors",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "3b227be",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocParallel",
         "Matrix",
@@ -109,10 +93,6 @@
       "Package": "BiocParallel",
       "Version": "1.32.5",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/BiocParallel",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "6110035",
-      "git_last_commit_date": "2022-12-22",
       "Requirements": [
         "BH",
         "R",
@@ -131,10 +111,6 @@
       "Package": "BiocSingular",
       "Version": "1.14.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/BiocSingular",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "6dc42b3",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "BiocParallel",
@@ -155,10 +131,6 @@
       "Package": "BiocVersion",
       "Version": "3.16.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/BiocVersion",
-      "git_branch": "master",
-      "git_last_commit": "c681e06",
-      "git_last_commit_date": "2022-04-26",
       "Requirements": [
         "R"
       ],
@@ -168,10 +140,6 @@
       "Package": "Biostrings",
       "Version": "2.66.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/Biostrings",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "3470ca7",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "GenomeInfoDb",
@@ -204,10 +172,6 @@
       "Package": "ComplexHeatmap",
       "Version": "2.14.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/ComplexHeatmap",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "57fcaa0",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "GetoptLong",
         "GlobalOptions",
@@ -246,10 +210,6 @@
       "Package": "DelayedArray",
       "Version": "0.24.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/DelayedArray",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "68ee3d0",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "IRanges",
@@ -267,10 +227,6 @@
       "Package": "DelayedMatrixStats",
       "Version": "1.20.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/DelayedMatrixStats",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "1ed1425",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "DelayedArray",
         "IRanges",
@@ -287,10 +243,6 @@
       "Package": "DropletUtils",
       "Version": "1.18.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/DropletUtils",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "2ea266c",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BH",
         "BiocGenerics",
@@ -332,10 +284,6 @@
       "Package": "GenomeInfoDb",
       "Version": "1.34.8",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/GenomeInfoDb",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "aa06fb0",
-      "git_last_commit_date": "2023-01-31",
       "Requirements": [
         "BiocGenerics",
         "GenomeInfoDbData",
@@ -363,10 +311,6 @@
       "Package": "GenomicRanges",
       "Version": "1.50.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/GenomicRanges",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "601b0fa",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "GenomeInfoDb",
@@ -411,10 +355,6 @@
       "Package": "HDF5Array",
       "Version": "1.26.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/HDF5Array",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "38b7bd6",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "DelayedArray",
@@ -436,10 +376,6 @@
       "Package": "IRanges",
       "Version": "2.32.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/IRanges",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "2b5c9fc",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -455,10 +391,6 @@
       "Package": "KEGGREST",
       "Version": "1.38.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/KEGGREST",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "4dfbff9",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "Biostrings",
         "R",
@@ -503,10 +435,6 @@
       "Package": "MatrixGenerics",
       "Version": "1.10.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/MatrixGenerics",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "6d9d907",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "matrixStats",
         "methods"
@@ -688,10 +616,6 @@
       "Package": "ResidualMatrix",
       "Version": "1.8.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/ResidualMatrix",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "888a93e",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "DelayedArray",
         "Matrix",
@@ -704,10 +628,6 @@
       "Package": "Rhdf5lib",
       "Version": "1.20.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/Rhdf5lib",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "7606799",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "R"
       ],
@@ -728,10 +648,6 @@
       "Package": "S4Vectors",
       "Version": "0.36.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/S4Vectors",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "af58701",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "R",
@@ -746,10 +662,6 @@
       "Package": "ScaledMatrix",
       "Version": "1.6.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/ScaledMatrix",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "45a29d3",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "DelayedArray",
         "Matrix",
@@ -762,10 +674,6 @@
       "Package": "SingleCellExperiment",
       "Version": "1.20.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/SingleCellExperiment",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "467f02c",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "DelayedArray",
@@ -796,10 +704,6 @@
       "Package": "SummarizedExperiment",
       "Version": "1.28.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/SummarizedExperiment",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "ba55dac",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "Biobase",
         "BiocGenerics",
@@ -818,14 +722,23 @@
       ],
       "Hash": "ae913ff30bce222686e66e45448fcfb6"
     },
+    "V8": {
+      "Package": "V8",
+      "Version": "4.3.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Rcpp",
+        "curl",
+        "jsonlite",
+        "utils"
+      ],
+      "Hash": "20d81ec18bde233d8cc3265761fe8c93"
+    },
     "XVector": {
       "Package": "XVector",
       "Version": "0.38.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/XVector",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "8cad084",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "IRanges",
@@ -884,10 +797,6 @@
       "Package": "batchelor",
       "Version": "1.14.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/batchelor",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "a5912c3",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "BiocNeighbors",
@@ -915,10 +824,6 @@
       "Package": "beachmat",
       "Version": "2.14.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/beachmat",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "5a4b85f",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "DelayedArray",
@@ -940,6 +845,16 @@
         "utils"
       ],
       "Hash": "0f4e9d8caa6feaa7e409ae6c30f2ca66"
+    },
+    "bigD": {
+      "Package": "bigD",
+      "Version": "0.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "93637e906f3fe962413912c956eb44db"
     },
     "bit": {
       "Package": "bit",
@@ -988,10 +903,6 @@
       "Package": "bluster",
       "Version": "1.8.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/bluster",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "156115c",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocNeighbors",
         "BiocParallel",
@@ -1380,10 +1291,6 @@
       "Package": "edgeR",
       "Version": "3.40.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/edgeR",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "0b25adc",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "R",
         "Rcpp",
@@ -1448,10 +1355,6 @@
       "Package": "fishpond",
       "Version": "2.4.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/fishpond",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "1b955ca",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "GenomicRanges",
         "IRanges",
@@ -1790,6 +1693,36 @@
       ],
       "Hash": "7d7f283939f563670a697165b2cf5560"
     },
+    "gt": {
+      "Package": "gt",
+      "Version": "0.9.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "base64enc",
+        "bigD",
+        "bitops",
+        "cli",
+        "commonmark",
+        "dplyr",
+        "fs",
+        "glue",
+        "htmltools",
+        "htmlwidgets",
+        "juicyjuice",
+        "magrittr",
+        "markdown",
+        "reactable",
+        "rlang",
+        "sass",
+        "scales",
+        "tibble",
+        "tidyselect",
+        "xml2"
+      ],
+      "Hash": "d55233a737e43e44987724e57dfec302"
+    },
     "gtable": {
       "Package": "gtable",
       "Version": "0.3.1",
@@ -1865,6 +1798,21 @@
         "utils"
       ],
       "Hash": "9d27e99cc90bd701c0a7a63e5923f9b7"
+    },
+    "htmlwidgets": {
+      "Package": "htmlwidgets",
+      "Version": "1.6.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "grDevices",
+        "htmltools",
+        "jsonlite",
+        "knitr",
+        "rmarkdown",
+        "yaml"
+      ],
+      "Hash": "b677ee5954471eaa974c0d099a343a1a"
     },
     "httpuv": {
       "Package": "httpuv",
@@ -1968,6 +1916,16 @@
         "methods"
       ],
       "Hash": "a4269a09a9b865579b2635c77e572374"
+    },
+    "juicyjuice": {
+      "Package": "juicyjuice",
+      "Version": "0.1.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "V8"
+      ],
+      "Hash": "3bcd11943da509341838da9399e18bce"
     },
     "kableExtra": {
       "Package": "kableExtra",
@@ -2078,10 +2036,6 @@
       "Package": "limma",
       "Version": "3.54.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/limma",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "1d1fa84",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "R",
         "grDevices",
@@ -2206,10 +2160,6 @@
       "Package": "metapod",
       "Version": "1.6.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/metapod",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "cfeaa95",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "Rcpp"
       ],
@@ -2236,10 +2186,6 @@
       "Package": "miQC",
       "Version": "1.6.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/miQC",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "de1de6e",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "R",
         "SingleCellExperiment",
@@ -2446,7 +2392,7 @@
     },
     "pkgload": {
       "Package": "pkgload",
-      "Version": "1.3.2",
+      "Version": "1.3.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2616,10 +2562,6 @@
       "Package": "qvalue",
       "Version": "2.30.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/qvalue",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "e8a4c22",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "R",
         "ggplot2",
@@ -2649,6 +2591,31 @@
         "R"
       ],
       "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
+    },
+    "reactR": {
+      "Package": "reactR",
+      "Version": "0.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "htmltools"
+      ],
+      "Hash": "75389c8091eb14ee21c6bc87a88b3809"
+    },
+    "reactable": {
+      "Package": "reactable",
+      "Version": "0.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "digest",
+        "htmltools",
+        "htmlwidgets",
+        "jsonlite",
+        "reactR"
+      ],
+      "Hash": "6069eb2a6597963eae0605c1875ff14c"
     },
     "readr": {
       "Package": "readr",
@@ -2685,7 +2652,7 @@
     },
     "remotes": {
       "Package": "remotes",
-      "Version": "2.4.2",
+      "Version": "2.4.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2699,13 +2666,13 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "0.17.0",
+      "Version": "1.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "ce3065fc1a0b64a859f55ac3998d6927"
+      "Hash": "c321cd99d56443dbffd1c9e673c0c1a2"
     },
     "reshape2": {
       "Package": "reshape2",
@@ -2724,10 +2691,6 @@
       "Package": "rhdf5",
       "Version": "2.42.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/rhdf5",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "fa26027",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "R",
         "Rhdf5lib",
@@ -2740,10 +2703,6 @@
       "Package": "rhdf5filters",
       "Version": "1.10.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/rhdf5filters",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "6131538",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "Rhdf5lib"
       ],
@@ -2900,10 +2859,6 @@
       "Package": "scater",
       "Version": "1.26.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/scater",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "a548ddc",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "BiocNeighbors",
@@ -2946,7 +2901,7 @@
       "RemoteRepo": "scpcaTools",
       "RemoteUsername": "AlexsLemonade",
       "RemoteRef": "main",
-      "RemoteSha": "39dbed38b3b906b132783f45b3e3a3a7a85bc729",
+      "RemoteSha": "e8371eba48d4c4e93ecf87817f46933fb0439849",
       "Requirements": [
         "BiocGenerics",
         "DropletUtils",
@@ -2971,16 +2926,12 @@
         "tidyr",
         "tximport"
       ],
-      "Hash": "ac287aa860a17a5fe3447762bcffaffc"
+      "Hash": "e61c96628323ecbe880e6f3ab6f57188"
     },
     "scran": {
       "Package": "scran",
       "Version": "1.26.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/scran",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "df66576",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BH",
         "BiocGenerics",
@@ -3012,10 +2963,6 @@
       "Package": "scuttle",
       "Version": "1.8.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/scuttle",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "dabf6b9",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "BiocGenerics",
         "BiocParallel",
@@ -3062,7 +3009,7 @@
     },
     "shiny": {
       "Package": "shiny",
-      "Version": "1.7.4",
+      "Version": "1.7.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -3130,10 +3077,6 @@
       "Package": "sparseMatrixStats",
       "Version": "1.10.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/sparseMatrixStats",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "75d85ba",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "Matrix",
         "MatrixGenerics",
@@ -3374,10 +3317,6 @@
       "Package": "tximport",
       "Version": "1.26.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/tximport",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "5ae7139",
-      "git_last_commit_date": "2022-11-01",
       "Requirements": [
         "methods",
         "stats",
@@ -3587,10 +3526,6 @@
       "Package": "zlibbioc",
       "Version": "1.44.0",
       "Source": "Bioconductor",
-      "git_url": "https://git.bioconductor.org/packages/zlibbioc",
-      "git_branch": "RELEASE_3_16",
-      "git_last_commit": "d39f0b0",
-      "git_last_commit_date": "2022-11-01",
       "Hash": "6f578730acbdfc7ce2ca49df29bb5352"
     }
   }

--- a/renv.lock
+++ b/renv.lock
@@ -3,8 +3,28 @@
     "Version": "4.2.3",
     "Repositories": [
       {
+        "Name": "BioCsoft",
+        "URL": "https://bioconductor.org/packages/3.16/bioc"
+      },
+      {
+        "Name": "BioCann",
+        "URL": "https://bioconductor.org/packages/3.16/data/annotation"
+      },
+      {
+        "Name": "BioCexp",
+        "URL": "https://bioconductor.org/packages/3.16/data/experiment"
+      },
+      {
+        "Name": "BioCworkflows",
+        "URL": "https://bioconductor.org/packages/3.16/workflows"
+      },
+      {
+        "Name": "BioCbooks",
+        "URL": "https://bioconductor.org/packages/3.16/books"
+      },
+      {
         "Name": "CRAN",
-        "URL": "https://cloud.r-project.org"
+        "URL": "https://packagemanager.posit.co/cran/latest"
       }
     ]
   },


### PR DESCRIPTION
**Issue Addressed**
Closes #375

**What is the purpose of these changes?**
Setting `workflow.use_conda` seemed to cause trouble depending on the version of snakemake (See #375), and there were potentially some other problems, so I'm trying to get things back to working.

**What changes did you make?**
The main change is reverting #371 and #365.
I also updated readmes to reflect current versions in the conda/renv files.
Finally, I took the chance to update the `renv` to 1.0.0, just for maybe some future reproducibility, which means that a few new packages were required. Look at the names of those for some little treats.

**Were there any other solutions that you tried?**

I had tried to look at just fixing #375 without reversions, but I can't find any documentation on the "right" way to set `use-conda` by default, so I think it is better to just require it to be done manually (or in an wrapper script)

**Any comments, concerns, or questions important for reviewers**

While this "works for me" in so far as the conda setup steps do run as expected both locally and on the server, I don't seem to be a robust test on my own. Everybody should download and try to install this locally using `conda`.

If we want to preserve the ability to run with renv, I suspect there may still be some `renv`-specific challenges that remain related to arm processors and older packages that might need to be compiled from source (I ran into a problem with `RCurl` on my machine, for example, but didn't try to fix it here). Fixing those kinds of issues probably would require updating the package versions in the `conda` environment to ones that we know work on M1 macs (and hopefully can be installed as binaries).

**Checklist**

Place an `x` in all boxes that you have completed.

- [x] I have run the most recent version of the code
- [ ] If I am adding in reports or generating any plots, I have reviewed the necessary reports
- [ ] I have added all necessary documentation (if applicable)