### PR TITLE
374 Update packages to fix error when building conda environment

### DIFF
--- a/components/dependencies.R
+++ b/components/dependencies.R
@@ -7,5 +7,6 @@
 #
 # library(dplyr)
 #
-library(uwot)
+library(remotes)
 library(markdown)
+library(uwot)

--- a/envs/scpca-renv.post-deploy.sh
+++ b/envs/scpca-renv.post-deploy.sh
@@ -8,9 +8,18 @@ fi
 
 SCPCATOOLS_VERS='main'
 
-# install github packages
+# install packages not on conda-forge
 Rscript --vanilla -e \
   "
+  # install Harmony from CRAN
+  remotes::install_version(
+    'harmony', 
+    version = '0.1.1', 
+    repos = 'https://cloud.r-project.org', 
+    upgrade = FALSE
+  )
+
+  # install ScPCA tools from Github
   remotes::install_github('AlexsLemonade/scpcaTools', ref='${SCPCATOOLS_VERS}', upgrade='never')
   require(scpcaTools) # check installation
   "

--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -325,5 +325,4 @@ dependencies:
   - r-yaml=2.3.7
   - r-zip=2.2.2
 variables:
-  R_LIBS_USER: null
   RENV_PROJECT: null

--- a/envs/scpca-renv.yaml
+++ b/envs/scpca-renv.yaml
@@ -51,6 +51,7 @@ dependencies:
   - bioconductor-tximport=1.26.0
   - bioconductor-xvector=0.38.0
   - bioconductor-zlibbioc=1.44.0
+  - conda-ecosystem-user-package-isolation=1.0
   - pandoc=2.19.2
   - r-abind=1.4_5
   - r-askpass=1.1

--- a/optional-integration-analysis/integration-report-template.Rmd
+++ b/optional-integration-analysis/integration-report-template.Rmd
@@ -13,14 +13,14 @@ params:
 title: "`r glue::glue('Integration analysis report for {params$integration_group}')`"
 author: "CCDL"
 date: "`r params$date`"
-output: 
+output:
   html_document:
     toc: true
     toc_depth: 2
     toc_float: true
     number_sections: true
     code_folding: hide
-editor_options: 
+editor_options:
   chunk_output_type: console
 ---
 
@@ -34,12 +34,12 @@ knitr::opts_chunk$set(
   warning = FALSE
 )
 
-# If project root is not provided use here::here() 
+# If project root is not provided use here::here()
 if (is.null(params$project_root)) {
   project_root <- here::here()
 } else {
   project_root <- params$project_root
-} 
+}
 
 # Tell knitr to knit from the project root to be able to load `renv` properly
 # This path goes into effect for SUBSEQUENT chunks, hence the need for 2 chunks
@@ -48,11 +48,6 @@ knitr::opts_knit$set(root.dir = project_root)
 # Source in set up function
 source(file.path(project_root, "utils", "setup-functions.R"))
 source(file.path(project_root, "utils", "integration-functions.R"))
-
-# Install `gt` package
-if(!("gt" %in% installed.packages())){
-  install.packages("gt", repos = "http://cran.us.r-project.org")
-}
 ```
 
 ```{r, include = FALSE}
@@ -84,7 +79,7 @@ integrated_sce <- readr::read_rds(params$integrated_sce)
 ```{r results='asis'}
 # pull out an SCE object for this section
 # all SCEs in the list should be equivalent for these calculations and plots
-sce_coldata <- colData(integrated_sce) |> 
+sce_coldata <- colData(integrated_sce) |>
   tibble::as_tibble()
 
 # How many batches?
@@ -125,12 +120,12 @@ batch_umaps <- integration_methods |>
                                      legend_labels = batch_plot_labels,
                                      seed = params$seed))
 batch_legend <- cowplot::get_legend(batch_umaps[[1]])
-  
+
 ggpubr::ggarrange(plotlist = batch_umaps,
-                  common.legend = TRUE, 
+                  common.legend = TRUE,
                   legend = "right",
-                  ncol = 2, 
-                  nrow = 2) 
+                  ncol = 2,
+                  nrow = 2)
 ```
 
 ## Batch ASW plots
@@ -177,7 +172,7 @@ Within-batch ARI values close to 1 indicate that biological heterogeneity has be
 
 ```{r}
 # List of SCE filepaths
-input_metadata <- readr::read_tsv(params$input_metadata_tsv) |> 
+input_metadata <- readr::read_tsv(params$input_metadata_tsv) |>
   dplyr::filter(integration_group == params$integration_group)
 sce_files <- input_metadata |>
   dplyr::pull(processed_sce_filepath)
@@ -197,7 +192,7 @@ within_batch_ari_df <-
     seed = params$seed
  ) |>
   dplyr::mutate(ari = as.numeric(ari))
-                                                  
+
 ```
 
 ```{r}

--- a/optional-integration-analysis/merge-sce.R
+++ b/optional-integration-analysis/merge-sce.R
@@ -5,8 +5,7 @@
 
 # Load libraries
 library(optparse)
-library(dplyr)
-library(SingleCellExperiment)
+
 
 # Declare command line options
 option_list <- list(
@@ -65,6 +64,9 @@ check_r_version()
 # Set up renv
 setup_renv(project_filepath = project_root)
 
+# Load additional library
+library(SingleCellExperiment)
+
 # Check that file extension for output file is correct
 if(!(stringr::str_ends(opt$output_sce_file, ".rds"))){
   stop("output file name must end in .rds")
@@ -90,7 +92,7 @@ if(is.null(opt$integration_group)) {
 }
 
 # List of SCE filepaths
-sce_files <- input_metadata$processed_sce_filepath |> 
+sce_files <- input_metadata$processed_sce_filepath |>
   purrr::set_names(input_metadata$library_id)
 
 # Check that input files exist

--- a/optional-integration-analysis/perform-integration.R
+++ b/optional-integration-analysis/perform-integration.R
@@ -67,11 +67,6 @@ check_r_version()
 # Set up renv
 setup_renv(project_filepath = project_root)
 
-# Harmony is not on conda-forge, so we install it here if needed
-if (!("harmony" %in% installed.packages())) {
-  remotes::install_version("harmony", version = "0.1.1", repos = "https://packagemanager.posit.co/cran/latest")
-}
-
 # Load additional libraries
 library(SingleCellExperiment)
 library(scpcaTools)


### PR DESCRIPTION
stacked on #376

closes #374

Here I cleaned up package installation to work when the CRAN mirror is not set by adding a `repos` argument to `remotes::install_version()`, which was causing at least some of the errors seen in #374.

I also removed the "on-the-fly" installation of `gt`, as we can install that through conda/renv just fine, and that installation was already part of #376.

Finally, I moved some package loading calls to after the `setup_renv` calls to prevent potential errors with incorrect versions of packages being loaded (or not  set if `renv` installation was used.

Same caveats apply here as in #376: This all seems to work for me, but I am not representative of all users!

I tested this by running 
```
snakemake --use-conda -s integration.snakefile -c4
```
Which ran without incident both locally and on the server.