### PR TITLE
Update scpcaTools version

### DIFF
--- a/envs/scpca-renv.post-deploy.sh
+++ b/envs/scpca-renv.post-deploy.sh
@@ -6,16 +6,16 @@ if [[ "$(uname)" == 'Darwin' && "$(uname -m)" == 'arm64' ]]; then
 fi
 
 
-SCPCATOOLS_VERS='main'
+SCPCATOOLS_VERS='v0.2.3'
 
 # install packages not on conda-forge
 Rscript --vanilla -e \
   "
   # install Harmony from CRAN
   remotes::install_version(
-    'harmony', 
-    version = '0.1.1', 
-    repos = 'https://cloud.r-project.org', 
+    'harmony',
+    version = '0.1.1',
+    repos = 'https://cloud.r-project.org',
     upgrade = FALSE
   )
 

--- a/renv.lock
+++ b/renv.lock
@@ -2893,15 +2893,15 @@
     },
     "scpcaTools": {
       "Package": "scpcaTools",
-      "Version": "0.2.2",
+      "Version": "0.2.3",
       "Source": "GitHub",
       "Remotes": "AlexsLemonade/scpcaData, github::immunogenomics/lisi",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteRepo": "scpcaTools",
       "RemoteUsername": "AlexsLemonade",
-      "RemoteRef": "main",
-      "RemoteSha": "e8371eba48d4c4e93ecf87817f46933fb0439849",
+      "RemoteRef": "v0.2.3",
+      "RemoteSha": "a4b95324fbc610c8345e656c40b8192d753ab8fa",
       "Requirements": [
         "BiocGenerics",
         "DropletUtils",
@@ -2926,7 +2926,7 @@
         "tidyr",
         "tximport"
       ],
-      "Hash": "e61c96628323ecbe880e6f3ab6f57188"
+      "Hash": "14b07390e481d6bfde7d3beac530a6f6"
     },
     "scran": {
       "Package": "scran",


### PR DESCRIPTION
In preparation for the release, all I'm doing here is updating the version of `scpcaTools` to use the new tagged version v0.2.3 instead of `main`.